### PR TITLE
Add missing member variable `m_loglevelStringInfo`

### DIFF
--- a/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.h
+++ b/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.h
@@ -70,6 +70,7 @@ private:
 	QString m_loglevelStringFatal;
 	QString m_loglevelStringError;
 	QString m_loglevelStringWarn;
+	QString m_loglevelStringInfo;
 	QString m_loglevelStringDebug;
 	QString m_loglevelStringTrace;
 


### PR DESCRIPTION
This fixes the build, which has been broken since commit 0d49b610a7d48cd1aeacd2d4735e297a6613b725.