### PR TITLE
Deboostify the code base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ ENDIF()
 
 FIND_PACKAGE(Boost REQUIRED)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 if(UNIX)
 	set(CMAKE_CXX_FLAGS_RELEASE        "-pipe -O2    -fvisibility-inlines-hidden -fdiagnostics-show-option -fno-strict-aliasing -Wall -Werror  -Wl,--as-needed -fPIC -DNDEBUG")
 	set(CMAKE_CXX_FLAGS_DEBUG          "-pipe -O0 -g -fvisibility-inlines-hidden -fdiagnostics-show-option -Wall -Werror -Wl,--as-needed -fPIC")

--- a/logWitch/ActionRules/Action.h
+++ b/logWitch/ActionRules/Action.h
@@ -7,7 +7,7 @@
 
 #ifndef ACTION_H_
 #define ACTION_H_
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <QtCore/QVariant>
 
 #include "ActionRules/DisplayItemData.h"
@@ -39,8 +39,8 @@ public:
     virtual bool isValid() const;
 };
 
-typedef boost::shared_ptr<Action> TSharedAction;
-typedef boost::shared_ptr<const Action> TconstSharedAction;
+typedef std::shared_ptr<Action> TSharedAction;
+typedef std::shared_ptr<const Action> TconstSharedAction;
 
 
 #endif /* ACTION_H_ */

--- a/logWitch/ActionRules/ActionDataRewriter.h
+++ b/logWitch/ActionRules/ActionDataRewriter.h
@@ -53,7 +53,7 @@ private:
     TSharedConstLogEntryParserModelConfiguration m_cfg;
 };
 
-typedef boost::shared_ptr<ActionDataRewriter> TSharedActionDataRewriter;
-typedef boost::shared_ptr<const ActionDataRewriter> TconstSharedActionDataRewriter;
+typedef std::shared_ptr<ActionDataRewriter> TSharedActionDataRewriter;
+typedef std::shared_ptr<const ActionDataRewriter> TconstSharedActionDataRewriter;
 
 #endif /* ACTIONCOLORROW_H_ */

--- a/logWitch/ActionRules/ActionDiscardRow.h
+++ b/logWitch/ActionRules/ActionDiscardRow.h
@@ -20,7 +20,7 @@ public:
 };
 
 
-typedef boost::shared_ptr<ActionDiscardRow> TSharedActionDiscardRow;
-typedef boost::shared_ptr<const ActionDiscardRow> TconstSharedActionDiscardRow;
+typedef std::shared_ptr<ActionDiscardRow> TSharedActionDiscardRow;
+typedef std::shared_ptr<const ActionDiscardRow> TconstSharedActionDiscardRow;
 
 #endif /* ACTIONREMOVEROW_H_ */

--- a/logWitch/ActionRules/ActionParser.cpp
+++ b/logWitch/ActionRules/ActionParser.cpp
@@ -16,7 +16,6 @@
 #include <boost/spirit/include/phoenix_fusion.hpp>
 #include <boost/spirit/include/phoenix_stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/variant/recursive_variant.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
 #include <QString>

--- a/logWitch/ActionRules/CompiledRulesStateSaver.cpp
+++ b/logWitch/ActionRules/CompiledRulesStateSaver.cpp
@@ -7,8 +7,6 @@
 
 #include "ActionRules/CompiledRulesStateSaver.h"
 
-#include <boost/bind/bind.hpp>
-
 #include <QAction>
 #include <QHeaderView>
 #include <QToolBar>
@@ -22,7 +20,7 @@
 
 #include "ContextMenuManipulateHeader.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 CompiledRulesStateSaver::CompiledRulesStateSaver(  TSharedConstLogEntryParserModelConfiguration cfg, TSharedRuleTable ruleTable )
     : m_compiledRuleView(NULL)
@@ -70,8 +68,8 @@ void CompiledRulesStateSaver::connectActions( FilterRuleSelectionWindow *wnd )
             wnd, SLOT(removeSelectionFromCompiled()));
 
     m_compiledRuleView->installEventFilter( new EventFilterToBoostFunction( this,
-            boost::bind( &evtFunc::keyPressed, _1, _2, Qt::Key_Delete,
-                    boost::function< void(void ) >( boost::bind( &FilterRuleSelectionWindow::removeSelectionFromCompiled, wnd ) ) ) ) );
+            std::bind( &evtFunc::keyPressed, _1, _2, Qt::Key_Delete,
+                    std::function< void(void ) >( std::bind( &FilterRuleSelectionWindow::removeSelectionFromCompiled, wnd ) ) ) ) );
 
     wnd->tieHeaderChangesTo( m_compiledRuleView );
 

--- a/logWitch/ActionRules/CompiledRulesStateSaver.h
+++ b/logWitch/ActionRules/CompiledRulesStateSaver.h
@@ -12,7 +12,6 @@
 #include <QtGui>
 #include <QTableView>
 
-#include <boost/shared_ptr.hpp>
 #include "ActionRules/TableModelRulesCompiled.h"
 #include "Models/LogEntryTableModel.h"
 #include "LogData/LogEntryParserModelConfiguration.h"
@@ -39,7 +38,7 @@ private:
     QAction *m_removeSelectedRules;
 };
 
-typedef boost::shared_ptr<CompiledRulesStateSaver> TSharedCompiledRulesStateSaver;
-typedef boost::shared_ptr<const CompiledRulesStateSaver> TconstCompiledRulesStateSaver;
+typedef std::shared_ptr<CompiledRulesStateSaver> TSharedCompiledRulesStateSaver;
+typedef std::shared_ptr<const CompiledRulesStateSaver> TconstCompiledRulesStateSaver;
 
 #endif /* COMPILEDRULESSTATESAVER_H_ */

--- a/logWitch/ActionRules/DisplayItemData.h
+++ b/logWitch/ActionRules/DisplayItemData.h
@@ -21,7 +21,7 @@ public:
     virtual QVariant toDisplay( int role ) const = 0;
 };
 
-typedef boost::shared_ptr<DisplayItemData> TSharedDisplayItemData;
-typedef boost::shared_ptr<const DisplayItemData> TconstSharedDisplayItemData;
+typedef std::shared_ptr<DisplayItemData> TSharedDisplayItemData;
+typedef std::shared_ptr<const DisplayItemData> TconstSharedDisplayItemData;
 
 #endif /* DISPLAYITEMDATA_H_ */

--- a/logWitch/ActionRules/Expression.h
+++ b/logWitch/ActionRules/Expression.h
@@ -26,8 +26,8 @@ public:
 
 std::ostream& operator<< (std::ostream &o, const Expression &e);
 
-typedef boost::shared_ptr<Expression> TSharedExpression;
-typedef boost::shared_ptr<const Expression> TconstSharedExpression;
+typedef std::shared_ptr<Expression> TSharedExpression;
+typedef std::shared_ptr<const Expression> TconstSharedExpression;
 
 
 #endif /* EXPRESSION_H_ */

--- a/logWitch/ActionRules/ExpressionFind.h
+++ b/logWitch/ActionRules/ExpressionFind.h
@@ -34,8 +34,8 @@ private:
 };
 
 
-typedef boost::shared_ptr<ExpressionFind> TSharedExpressionFind;
-typedef boost::shared_ptr<const ExpressionFind> TconstSharedExpressionFind;
+typedef std::shared_ptr<ExpressionFind> TSharedExpressionFind;
+typedef std::shared_ptr<const ExpressionFind> TconstSharedExpressionFind;
 
 
 #endif /* EXPRESSIONFIND_H_ */

--- a/logWitch/ActionRules/ExpressionMatch.h
+++ b/logWitch/ActionRules/ExpressionMatch.h
@@ -31,7 +31,7 @@ private:
 };
 
 
-typedef boost::shared_ptr<ExpressionMatch> TSharedExpressionMatch;
-typedef boost::shared_ptr<const ExpressionMatch> TconstSharedExpressionMatch;
+typedef std::shared_ptr<ExpressionMatch> TSharedExpressionMatch;
+typedef std::shared_ptr<const ExpressionMatch> TconstSharedExpressionMatch;
 
 #endif /* EXPRESSIONVALUEGETTER_H_ */

--- a/logWitch/ActionRules/ExpressionOperators.h
+++ b/logWitch/ActionRules/ExpressionOperators.h
@@ -24,8 +24,8 @@ private:
     TSharedExpression m_expr;
 };
 
-typedef boost::shared_ptr<ExpressionOpNegate> TSharedExpressionOpNegate;
-typedef boost::shared_ptr<const ExpressionOpNegate> TconstSharedExpressionOpNegate;
+typedef std::shared_ptr<ExpressionOpNegate> TSharedExpressionOpNegate;
+typedef std::shared_ptr<const ExpressionOpNegate> TconstSharedExpressionOpNegate;
 
 class ExpressionConst
     :public Expression
@@ -42,8 +42,8 @@ private:
     bool m_value;
 };
 
-typedef boost::shared_ptr<ExpressionConst> TSharedExpressionConst;
-typedef boost::shared_ptr<const ExpressionConst> TconstSharedExpressionConst;
+typedef std::shared_ptr<ExpressionConst> TSharedExpressionConst;
+typedef std::shared_ptr<const ExpressionConst> TconstSharedExpressionConst;
 
 class ExpressionOpOr
     :public Expression
@@ -60,8 +60,8 @@ private:
     TSharedExpression m_left, m_right;
 };
 
-typedef boost::shared_ptr<ExpressionOpOr> TSharedExpressionOpOr;
-typedef boost::shared_ptr<const ExpressionOpOr> TconstSharedExpressionOpOr;
+typedef std::shared_ptr<ExpressionOpOr> TSharedExpressionOpOr;
+typedef std::shared_ptr<const ExpressionOpOr> TconstSharedExpressionOpOr;
 
 class ExpressionOpAnd
     :public Expression
@@ -78,8 +78,8 @@ private:
     TSharedExpression m_left, m_right;
 };
 
-typedef boost::shared_ptr<ExpressionOpAnd> TSharedExpressionOpAnd;
-typedef boost::shared_ptr<const ExpressionOpAnd> TconstSharedExpressionOpAnd;
+typedef std::shared_ptr<ExpressionOpAnd> TSharedExpressionOpAnd;
+typedef std::shared_ptr<const ExpressionOpAnd> TconstSharedExpressionOpAnd;
 
 class ExpressionOpXOr
     :public Expression
@@ -96,7 +96,7 @@ private:
     TSharedExpression m_left, m_right;
 };
 
-typedef boost::shared_ptr<ExpressionOpXOr> TSharedExpressionOpXOr;
-typedef boost::shared_ptr<const ExpressionOpXOr> TconstSharedExpressionOpXOr;
+typedef std::shared_ptr<ExpressionOpXOr> TSharedExpressionOpXOr;
+typedef std::shared_ptr<const ExpressionOpXOr> TconstSharedExpressionOpXOr;
 
 #endif /* EXPRESSIONOPERATORS_H_ */

--- a/logWitch/ActionRules/ExpressionParser.cpp
+++ b/logWitch/ActionRules/ExpressionParser.cpp
@@ -13,7 +13,6 @@
 #include <boost/spirit/include/phoenix_fusion.hpp>
 #include <boost/spirit/include/phoenix_stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/variant/recursive_variant.hpp>
 
 #include <QString>
 

--- a/logWitch/ActionRules/ExpressionRegEx.h
+++ b/logWitch/ActionRules/ExpressionRegEx.h
@@ -35,8 +35,8 @@ private:
     QRegExp m_regex;
 };
 
-typedef boost::shared_ptr<ExpressionRegEx> TSharedExpressionRegEx;
-typedef boost::shared_ptr<const ExpressionRegEx> TconstSharedExpressionRegEx;
+typedef std::shared_ptr<ExpressionRegEx> TSharedExpressionRegEx;
+typedef std::shared_ptr<const ExpressionRegEx> TconstSharedExpressionRegEx;
 
 
 #endif /* EXPRESSIONREGEX_H_ */

--- a/logWitch/ActionRules/FilterRuleCompiled.h
+++ b/logWitch/ActionRules/FilterRuleCompiled.h
@@ -6,7 +6,6 @@
  */
 #ifndef FILTERRULECOMPILED_H_
 #define FILTERRULECOMPILED_H_
-#include <boost/shared_ptr.hpp>
 
 #include "ActionRules/Action.h"
 #include "ActionRules/ActionParser.h"
@@ -17,8 +16,8 @@
 #include "LogData/LogEntryParserModelConfiguration.h"
 
 class FilterRuleCompiled;
-typedef boost::shared_ptr<FilterRuleCompiled> TSharedFilterRuleCompiled;
-typedef boost::shared_ptr<const FilterRuleCompiled> TSharedConstFilterRuleCompiled;
+typedef std::shared_ptr<FilterRuleCompiled> TSharedFilterRuleCompiled;
+typedef std::shared_ptr<const FilterRuleCompiled> TSharedConstFilterRuleCompiled;
 
 class FilterRuleCompiled
 : public QObject

--- a/logWitch/ActionRules/FilterRuleSelectionWindow.cpp
+++ b/logWitch/ActionRules/FilterRuleSelectionWindow.cpp
@@ -7,8 +7,6 @@
 
 #include "FilterRuleSelectionWindow.h"
 
-#include <boost/bind/bind.hpp>
-
 #include <QHeaderView>
 #include <QLabel>
 #include <QtGui>
@@ -27,7 +25,7 @@
 
 #include "ContextMenuManipulateHeader.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 const QString filterRuleTableState_Identifier("FilterRuleSelectionTableState");
 
@@ -60,8 +58,8 @@ FilterRuleSelectionWindow::FilterRuleSelectionWindow( QWidget* parent )
 
     // Filter "Key_Delete" Key and pass it to trashSelectedRules.
     m_ruleView->installEventFilter( new EventFilterToBoostFunction( this,
-            boost::bind( &evtFunc::keyPressed, _1, _2, Qt::Key_Delete,
-                    boost::function< void(void ) >( boost::bind( &FilterRuleSelectionWindow::trashSelectedRules, this ) ) ) ) );
+            std::bind( &evtFunc::keyPressed, _1, _2, Qt::Key_Delete,
+                    std::function< void(void ) >( std::bind( &FilterRuleSelectionWindow::trashSelectedRules, this ) ) ) ) );
 
     QWidget *displayWidget = new QWidget(); //This is the pane
     QVBoxLayout* vbox = new QVBoxLayout(displayWidget);

--- a/logWitch/ActionRules/Rule.h
+++ b/logWitch/ActionRules/Rule.h
@@ -7,7 +7,6 @@
 
 #ifndef RULE_H_
 #define RULE_H_
-#include <boost/shared_ptr.hpp>
 
 #include <QtCore/QtCore>
 
@@ -35,7 +34,7 @@ private:
     TconstSharedAction m_action;
 };
 
-typedef boost::shared_ptr<Rule> TSharedRule;
-typedef boost::shared_ptr<const Rule> TconstSharedRule;
+typedef std::shared_ptr<Rule> TSharedRule;
+typedef std::shared_ptr<const Rule> TconstSharedRule;
 
 #endif /* RULE_H_ */

--- a/logWitch/ActionRules/RuleTable.h
+++ b/logWitch/ActionRules/RuleTable.h
@@ -12,15 +12,14 @@
 #include <map>
 #include <string>
 
-#include <boost/shared_ptr.hpp>
 #include <QtCore/qobject.h>
 
 #include "Rule.h"
 
 class RuleTable;
 
-typedef boost::shared_ptr<RuleTable> TSharedRuleTable;
-typedef boost::shared_ptr<const RuleTable> TconstSharedRuleTable;
+typedef std::shared_ptr<RuleTable> TSharedRuleTable;
+typedef std::shared_ptr<const RuleTable> TconstSharedRuleTable;
 
 class RuleTable
     :public QObject
@@ -42,7 +41,7 @@ public:
 //        TRuleList::iterator it;
 //        for( it = m_rules.begin(); it != m_rules.end(); ++it )
 //        {
-//            boost::shared_ptr<T> rule = boost::dynamic_pointer_cast<T>( *it );
+//            std::shared_ptr<T> rule = std::dynamic_pointer_cast<T>( *it );
 //            if( rule )
 //                table->m_rules.push_back( rule );
 //        }
@@ -66,7 +65,7 @@ public:
         TRuleSet::const_iterator it;
         for( it = m_rules.begin(); it != m_rules.end(); ++it )
         {
-            T action = boost::dynamic_pointer_cast<typename T::element_type>( (*it)->getAction() );
+            T action = std::dynamic_pointer_cast<typename T::element_type>( (*it)->getAction() );
             if( action && (*it)->checkRule( entry ) )
                 actions.push_back( action );
         }
@@ -79,7 +78,7 @@ public:
         TRuleSet::const_iterator it;
         for( it = m_rules.begin(); it != m_rules.end(); ++it )
         {
-            T action = boost::dynamic_pointer_cast<typename T::element_type>( (*it)->getAction() );
+            T action = std::dynamic_pointer_cast<typename T::element_type>( (*it)->getAction() );
             if( action && (*it)->checkRule( entry ) )
                 return true;
         }
@@ -96,7 +95,7 @@ public:
         TRuleSet::const_iterator it;
         for( it = m_rules.begin(); it != m_rules.end(); ++it )
         {
-            T action = boost::dynamic_pointer_cast<typename T::element_type>( (*it)->getAction() );
+            T action = std::dynamic_pointer_cast<typename T::element_type>( (*it)->getAction() );
             if( action )
                 rVec.push_back( (*it)->getExpression() );
         }

--- a/logWitch/ActionRules/TableModelRulesCompiled.cpp
+++ b/logWitch/ActionRules/TableModelRulesCompiled.cpp
@@ -7,14 +7,13 @@
 
 #include "TableModelRulesCompiled.h"
 
-#include <boost/bind/bind.hpp>
 #include <QtGui>
 
 #include "ActionRules/ActionDataRewriter.h"
 #include "ActionRules/FilterRuleCompiled.h"
 #include "FilterRuleCompiled.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 const QString TableModelRulesCompiled::ruleMimeType("application/x-de.steckmann.LogWitch.rule");
 
@@ -270,7 +269,7 @@ QString TableModelRulesCompiled::getRule( const int row ) const
 bool TableModelRulesCompiled::hasRule( const QString &rule ) const
 {
     TCompiledRulesTable::const_iterator it;
-    it = std::find_if(m_table.begin(), m_table.end(), boost::bind( &ruleEquals, _1, rule ) );
+    it = std::find_if(m_table.begin(), m_table.end(), std::bind( &ruleEquals, _1, rule ) );
     return it != m_table.end();
 }
 

--- a/logWitch/ActionRules/TableModelRulesCompiled.h
+++ b/logWitch/ActionRules/TableModelRulesCompiled.h
@@ -9,8 +9,6 @@
 #define TABLEMODELRULESCOMPILED_H_
 #include <vector>
 
-#include <boost/shared_ptr.hpp>
-
 #include <QAbstractTableModel>
 #include <QtCore>
 
@@ -18,7 +16,7 @@
 #include "ActionRules/FilterRuleCompiled.h"
 #include "ActionRules/RuleTable.h"
 
-using boost::shared_ptr;
+using std::shared_ptr;
 
 class TableModelRulesCompiled
      :public QAbstractTableModel

--- a/logWitch/ActionRules/ValueGetter.h
+++ b/logWitch/ActionRules/ValueGetter.h
@@ -8,7 +8,6 @@
 #ifndef VALUEGETTER_H_
 #define VALUEGETTER_H_
 #include <iostream>
-#include <boost/shared_ptr.hpp>
 
 #include "LogData/LogEntry.h"
 #include "Types.h"
@@ -25,8 +24,8 @@ public:
     virtual std::ostream &out( std::ostream &o, bool extended = false ) const = 0;
 };
 
-typedef boost::shared_ptr<ValueGetter> TSharedValueGetter;
-typedef boost::shared_ptr<const ValueGetter> TconstSharedValueGetter;
+typedef std::shared_ptr<ValueGetter> TSharedValueGetter;
+typedef std::shared_ptr<const ValueGetter> TconstSharedValueGetter;
 
 std::ostream& operator<< (std::ostream &o, const ValueGetter &e);
 

--- a/logWitch/ActionRules/ValueGetterLogEntry.cpp
+++ b/logWitch/ActionRules/ValueGetterLogEntry.cpp
@@ -7,7 +7,6 @@
 
 #include "ActionRules/ValueGetterLogEntry.h"
 
-#include <boost/shared_ptr.hpp>
 
 #include "LogData/LogEntryFactory.h"
 #include "LogData/LogEntry.h"

--- a/logWitch/ActionRules/ValueGetterLogEntry.h
+++ b/logWitch/ActionRules/ValueGetterLogEntry.h
@@ -8,7 +8,6 @@
 #ifndef VALUEGETTERLOGENTRY_H_
 #define VALUEGETTERLOGENTRY_H_
 
-#include <boost/shared_ptr.hpp>
 #include <QtCore/QtCore>
 
 #include "LogData/LogEntry.h"
@@ -45,7 +44,7 @@ private:
     int m_fieldId;
 };
 
-typedef boost::shared_ptr<ValueGetterLogEntry> TSharedValueGetterLogEntry;
-typedef boost::shared_ptr<const ValueGetterLogEntry> TconstSharedValueGetterLogEntry;
+typedef std::shared_ptr<ValueGetterLogEntry> TSharedValueGetterLogEntry;
+typedef std::shared_ptr<const ValueGetterLogEntry> TconstSharedValueGetterLogEntry;
 
 #endif /* VALUEGETTERLOGENTRY_H_ */

--- a/logWitch/ContextMenuManipulateHeader.cpp
+++ b/logWitch/ContextMenuManipulateHeader.cpp
@@ -7,8 +7,6 @@
 
 #include "ContextMenuManipulateHeader.h"
 
-#include <boost/bind/bind.hpp>
-
 #include "GUITools/SlotToBoostFunction.h"
 #include "GUITools/SynchronizedHeaderView.h"
 
@@ -49,7 +47,7 @@ void ContextMenuManipulateHeader::contextMenuRequest(const QPoint & pos)
         connect(action, SIGNAL(triggered()),
         // Destruction of this will be handled by the action itself.
             new SlotToBoostFunction(action,
-                boost::bind(&SynchronizedHeaderView::showSection, syncHeader,
+                std::bind(&SynchronizedHeaderView::showSection, syncHeader,
                     i)), SLOT(handleSignal()));
       }
       else
@@ -57,7 +55,7 @@ void ContextMenuManipulateHeader::contextMenuRequest(const QPoint & pos)
         connect(action, SIGNAL(triggered()),
             // Destruction of this will be handled by the action itself.
             new SlotToBoostFunction(action,
-                boost::bind(&QHeaderView::showSection, m_header, i)),
+                std::bind(&QHeaderView::showSection, m_header, i)),
             SLOT(handleSignal()));
       }
     }

--- a/logWitch/FilterListView.cpp
+++ b/logWitch/FilterListView.cpp
@@ -10,7 +10,7 @@
 #include "LogData/LogEntryParserModelConfiguration.h"
 #include "LogData/LogEntryFactory.h"
 
-FilterListView::FilterListView( QObject *parent, boost::shared_ptr<const LogEntryParserModelConfiguration> config, const int attr )
+FilterListView::FilterListView( QObject *parent, std::shared_ptr<const LogEntryParserModelConfiguration> config, const int attr )
 : QTreeView( )
 , m_config( config )
 , m_attr( attr )

--- a/logWitch/FilterListView.h
+++ b/logWitch/FilterListView.h
@@ -7,7 +7,6 @@
 
 #ifndef FILTERLISTVIEW_H_
 #define FILTERLISTVIEW_H_
-#include <boost/shared_ptr.hpp>
 
 #include <QAction>
 #include <QMenu>
@@ -22,7 +21,7 @@ class FilterListView
 {
         Q_OBJECT
 public:
-    FilterListView( QObject *parent, boost::shared_ptr<const LogEntryParserModelConfiguration> cfg, const int attr );
+    FilterListView( QObject *parent, std::shared_ptr<const LogEntryParserModelConfiguration> cfg, const int attr );
     ~FilterListView();
 
     void addToTabs( QTabWidget *tabs, LogEntryTableWindow* widget  );
@@ -31,7 +30,7 @@ public slots:
     void contextMenuPopup( const QPoint &pos);
 
 private:
-    boost::shared_ptr<const LogEntryParserModelConfiguration> m_config;
+    std::shared_ptr<const LogEntryParserModelConfiguration> m_config;
 
     StringCacheTreeModel *m_strModel;
     int m_attr;

--- a/logWitch/GUI/QuickSearchBar.cpp
+++ b/logWitch/GUI/QuickSearchBar.cpp
@@ -57,19 +57,19 @@ void QuickSearchLineEdit::dropEvent(QDropEvent *event)
   {
     event->accept();
     event->setDropAction(Qt::CopyAction);
-    boost::shared_ptr<FilterRuleCompiled> rule(
+    std::shared_ptr<FilterRuleCompiled> rule(
         new FilterRuleCompiled(event->mimeData()->text()) );
 
     // Now decide what we can do with this rule...
     auto expression = rule->getExpression();
 
     bool expressionSet = false;
-    auto expressionFind = boost::dynamic_pointer_cast<ExpressionFind>( expression );
-    auto expressionRe = boost::dynamic_pointer_cast<ExpressionRegEx>( expression );
+    auto expressionFind = std::dynamic_pointer_cast<ExpressionFind>( expression );
+    auto expressionRe = std::dynamic_pointer_cast<ExpressionRegEx>( expression );
 
     if (expressionFind) {
       TconstSharedValueGetter vg = expressionFind->getValueGetter();
-      boost::shared_ptr<const ValueGetterLogEntry> vgLe = boost::dynamic_pointer_cast<const ValueGetterLogEntry>(vg);
+      std::shared_ptr<const ValueGetterLogEntry> vgLe = std::dynamic_pointer_cast<const ValueGetterLogEntry>(vg);
       if (vgLe && vgLe->getName() == "message") {
         setText(expressionFind->getPattern());
         m_qsBar->setSearchMode(QuickSearchBar::Text);
@@ -78,7 +78,7 @@ void QuickSearchLineEdit::dropEvent(QDropEvent *event)
     }
     else if (expressionRe) {
       TconstSharedValueGetter vg = expressionRe->getValueGetter();
-      boost::shared_ptr<const ValueGetterLogEntry> vgLe = boost::dynamic_pointer_cast<const ValueGetterLogEntry>(vg);
+      std::shared_ptr<const ValueGetterLogEntry> vgLe = std::dynamic_pointer_cast<const ValueGetterLogEntry>(vg);
       if (vgLe && vgLe->getName() == "message") {
         setText(expressionRe->getPattern());
         m_qsBar->setSearchMode(QuickSearchBar::Regex);
@@ -101,7 +101,7 @@ void QuickSearchLineEdit::dropEvent(QDropEvent *event)
 
 
 QuickSearchBar::QuickSearchBar(LogEntryTableWindow* parent
-    , boost::shared_ptr<LogEntryTableModel> model
+    , std::shared_ptr<LogEntryTableModel> model
     , const QString& colorCode)
 : QWidget(parent)
 , m_model(model)

--- a/logWitch/GUI/QuickSearchBar.h
+++ b/logWitch/GUI/QuickSearchBar.h
@@ -25,7 +25,7 @@ class QuickSearchBar:
 {
   Q_OBJECT
 public:
-  QuickSearchBar(LogEntryTableWindow* parent, boost::shared_ptr<LogEntryTableModel> model, const QString& colorCode = "#81BEF7");
+  QuickSearchBar(LogEntryTableWindow* parent, std::shared_ptr<LogEntryTableModel> model, const QString& colorCode = "#81BEF7");
   virtual ~QuickSearchBar();
 
   enum SearchModes { Regex, Text, Expression};
@@ -59,7 +59,7 @@ public slots:
 
 private:
 
-  boost::shared_ptr<LogEntryTableModel> m_model;
+  std::shared_ptr<LogEntryTableModel> m_model;
 
   LogEntryTableWindow* m_logWindow;
 

--- a/logWitch/GUITools/EventFilterToBoostFunction.cpp
+++ b/logWitch/GUITools/EventFilterToBoostFunction.cpp
@@ -11,7 +11,7 @@
 
 namespace evtFunc
 {
-    bool keyPressed(QObject *o, QEvent *e, int keycode, boost::function<void()> f )
+    bool keyPressed(QObject *o, QEvent *e, int keycode, std::function<void()> f )
     {
         if (e->type() == QEvent::KeyPress )
         {

--- a/logWitch/GUITools/EventFilterToBoostFunction.h
+++ b/logWitch/GUITools/EventFilterToBoostFunction.h
@@ -10,18 +10,16 @@
 
 #include <QtCore>
 
-#include <boost/function.hpp>
-
 /**
  * This class makes event filtering more easy, it maps the eventFilter to a more
- * easy to implement function, which can also be used with boost::bind.
+ * easy to implement function, which can also be used with std::bind.
  */
 class EventFilterToBoostFunction
 : public QObject
 {
     Q_OBJECT
 public:
-    EventFilterToBoostFunction( QObject * parent, boost::function< bool (QObject *, QEvent *)> const & func):
+    EventFilterToBoostFunction( QObject * parent, std::function< bool (QObject *, QEvent *)> const & func):
         QObject( parent ), m_func( func )
     {  }
 
@@ -32,7 +30,7 @@ protected:
     }
 
 private:
-    boost::function< bool (QObject *, QEvent *)> m_func;
+    std::function< bool (QObject *, QEvent *)> m_func;
 };
 
 namespace evtFunc
@@ -42,7 +40,7 @@ namespace evtFunc
      * This object executes f if the event is a keyPressed event with the given
      * keycode.
      */
-    bool keyPressed(QObject *o, QEvent *e, int keycode, boost::function<void()> f );
+    bool keyPressed(QObject *o, QEvent *e, int keycode, std::function<void()> f );
 }
 
 #endif /* EVENTFILTERTOBOOSTFUNCTION_H_ */

--- a/logWitch/GUITools/GetSetStateSaver.hxx
+++ b/logWitch/GUITools/GetSetStateSaver.hxx
@@ -8,7 +8,6 @@
 #ifndef DOCKWIDGETSTATESAVER_H_
 #define DOCKWIDGETSTATESAVER_H_
 
-#include <boost/enable_shared_from_this.hpp>
 #include <QtGui>
 #include <QtCore>
 
@@ -52,16 +51,16 @@ public:
 template<class T>
 class GetSetStateSaver
 	: public ObjectStateSavingInterface
-	, public boost::enable_shared_from_this<GetSetStateSaver<T> >
+	, public std::enable_shared_from_this<GetSetStateSaver<T> >
 {
 private:
 	GetSetStateSaver();
 
 public:
-	static boost::shared_ptr<GetSetStateSaver<T> > generate();
+	static std::shared_ptr<GetSetStateSaver<T> > generate();
 
 public:
-    boost::shared_ptr<ObjectState> dumpState( QObject *obj, QObject * ) const;
+    std::shared_ptr<ObjectState> dumpState( QObject *obj, QObject * ) const;
     void replayState( QObject *obj, QObject *, const ObjectState *state ) const;
 
 private:
@@ -71,7 +70,7 @@ private:
         friend class GetSetStateSaver<T>;
     public:
 
-        state( boost::shared_ptr<const ObjectStateSavingInterface> ptr, QObject *dock, typename T::value widget )
+        state( std::shared_ptr<const ObjectStateSavingInterface> ptr, QObject *dock, typename T::value widget )
             : ObjectState( ptr, dock ), m_widget( widget ) { }
     private:
         typename T::value m_widget;
@@ -79,7 +78,7 @@ private:
 };
 
 template<class T>
-boost::shared_ptr<GetSetStateSaver<T> > GetSetStateSaver<T>::generate()
+std::shared_ptr<GetSetStateSaver<T> > GetSetStateSaver<T>::generate()
 {
     shared_ptr<GetSetStateSaver<T> > obj( new GetSetStateSaver<T>() );
     return obj;
@@ -91,7 +90,7 @@ GetSetStateSaver<T>::GetSetStateSaver()
 }
 
 template<class T>
-boost::shared_ptr<ObjectState> GetSetStateSaver<T>::dumpState( QObject *obj, QObject * ) const
+std::shared_ptr<ObjectState> GetSetStateSaver<T>::dumpState( QObject *obj, QObject * ) const
 {
     DEBUG_WIDGETSTATESAFER("dumping state" << obj);
 
@@ -99,12 +98,12 @@ boost::shared_ptr<ObjectState> GetSetStateSaver<T>::dumpState( QObject *obj, QOb
     if( wi )
     {
         DEBUG_WIDGETSTATESAFER( "Saving old widget: " << T::get( wi ));
-        return boost::shared_ptr<ObjectState>(new state( this->shared_from_this(), obj, T::get( wi ) ));
+        return std::shared_ptr<ObjectState>(new state( this->shared_from_this(), obj, T::get( wi ) ));
     }
     else
     {
         DEBUG_WIDGETSTATESAFER("Ignoring: Cast failed");
-        return boost::shared_ptr<ObjectState>(new ObjectState());
+        return std::shared_ptr<ObjectState>(new ObjectState());
     }
 }
 

--- a/logWitch/GUITools/SignalMultiplexer.cpp
+++ b/logWitch/GUITools/SignalMultiplexer.cpp
@@ -6,7 +6,6 @@
  *
  */
 #include "SignalMultiplexer.h"
-#include <boost/foreach.hpp>
 
 SignalMultiplexer::SignalMultiplexer(QObject *parent )
     : QObject( parent )
@@ -91,7 +90,7 @@ void SignalMultiplexer::setObject(
     StateConnectionsForObjects::iterator it = m_connectionStates.find( (QObject *)m_object );
     if( it != m_connectionStates.end() )
     {
-        BOOST_FOREACH( connectionState & s, it->second )
+        for ( connectionState & s : it->second )
         {
             disconnect( s );
         }
@@ -102,7 +101,7 @@ void SignalMultiplexer::setObject(
     it = m_connectionStates.find( (QObject *)m_object );
     if( it != m_connectionStates.end() )
     {
-        BOOST_FOREACH( connectionState & s, it->second )
+        for ( connectionState & s : it->second )
         {
             connect( s );
         }

--- a/logWitch/GUITools/SignalMultiplexerStateApplier.cpp
+++ b/logWitch/GUITools/SignalMultiplexerStateApplier.cpp
@@ -9,9 +9,9 @@
 #include "WidgetStateSaver.h"
 #include "GUITools/SignalMultiplexer.h"
 
-boost::shared_ptr<SignalMultiplexerStateApplier> SignalMultiplexerStateApplier::generate( SignalMultiplexer *mul)
+std::shared_ptr<SignalMultiplexerStateApplier> SignalMultiplexerStateApplier::generate( SignalMultiplexer *mul)
 {
-    boost::shared_ptr<SignalMultiplexerStateApplier> obj( new SignalMultiplexerStateApplier( mul ) );
+    std::shared_ptr<SignalMultiplexerStateApplier> obj( new SignalMultiplexerStateApplier( mul ) );
     obj->m_ptrToMyself = obj;
 
     return obj;
@@ -23,9 +23,9 @@ SignalMultiplexerStateApplier::SignalMultiplexerStateApplier( SignalMultiplexer 
 
 }
 
-boost::shared_ptr<ObjectState> SignalMultiplexerStateApplier::dumpState( QObject *, QObject * ) const
+std::shared_ptr<ObjectState> SignalMultiplexerStateApplier::dumpState( QObject *, QObject * ) const
 {
-    return boost::shared_ptr<ObjectState>( new ObjectState( m_ptrToMyself.lock(), NULL ) );
+    return std::shared_ptr<ObjectState>( new ObjectState( m_ptrToMyself.lock(), NULL ) );
 }
 
 void SignalMultiplexerStateApplier::replayState( QObject *, QObject *parent, const ObjectState * ) const

--- a/logWitch/GUITools/SignalMultiplexerStateApplier.h
+++ b/logWitch/GUITools/SignalMultiplexerStateApplier.h
@@ -8,8 +8,6 @@
 #ifndef SIGNALMULTIPLEXERSTATEAPPLIER_H_
 #define SIGNALMULTIPLEXERSTATEAPPLIER_H_
 
-#include <boost/weak_ptr.hpp>
-
 #include "WidgetStateSaver.h"
 
 class QWidget;
@@ -22,15 +20,15 @@ private:
         SignalMultiplexerStateApplier( SignalMultiplexer *);
 
 public:
-    static boost::shared_ptr<SignalMultiplexerStateApplier> generate( SignalMultiplexer *);
+    static std::shared_ptr<SignalMultiplexerStateApplier> generate( SignalMultiplexer *);
 
 public:
-    boost::shared_ptr<ObjectState> dumpState( QObject *obj, QObject * ) const;
+    std::shared_ptr<ObjectState> dumpState( QObject *obj, QObject * ) const;
     void replayState( QObject *obj, QObject *, const ObjectState *state ) const;
 
 private:
 
-    boost::weak_ptr<SignalMultiplexerStateApplier> m_ptrToMyself;
+    std::weak_ptr<SignalMultiplexerStateApplier> m_ptrToMyself;
 
     SignalMultiplexer *m_multiplexer;
 };

--- a/logWitch/GUITools/SlotToBoostFunction.h
+++ b/logWitch/GUITools/SlotToBoostFunction.h
@@ -9,14 +9,12 @@
 #define SLOTTOBOOSTFUNCTION_H_
 #include <QtCore>
 
-#include <boost/function.hpp>
-
 class SlotToBoostFunction
 : public QObject
 {
     Q_OBJECT
 public:
-    SlotToBoostFunction( QObject * parent, boost::function<void(void)> const & func):
+    SlotToBoostFunction( QObject * parent, std::function<void(void)> const & func):
         QObject( parent ), m_func( func )
     {  }
 
@@ -27,7 +25,7 @@ public slots:
     }
 
 private:
-  boost::function<void(void)> m_func;
+  std::function<void(void)> m_func;
 };
 
 class SlotToBoostFunction_int_int_int
@@ -35,7 +33,7 @@ class SlotToBoostFunction_int_int_int
 {
     Q_OBJECT
 public:
-    SlotToBoostFunction_int_int_int( QObject * parent, boost::function<void(int,int,int)> const & func):
+    SlotToBoostFunction_int_int_int( QObject * parent, std::function<void(int,int,int)> const & func):
         QObject( parent ), m_func( func )
     {  }
 
@@ -46,7 +44,7 @@ public slots:
     }
 
 private:
-  boost::function<void(int,int,int)> m_func;
+  std::function<void(int,int,int)> m_func;
 };
 
 #endif /* SLOTTOBOOSTFUNCTION_H_ */

--- a/logWitch/GUITools/SynchronizedHeaderView.cpp
+++ b/logWitch/GUITools/SynchronizedHeaderView.cpp
@@ -7,11 +7,9 @@
 
 #include "SynchronizedHeaderView.h"
 
-#include <boost/bind/bind.hpp>
-
 #include "GUITools/SlotToBoostFunction.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 HeaderViewGroup::HeaderViewGroup()
 : m_positionSyncNeeded( false )
@@ -36,18 +34,18 @@ void HeaderViewGroup::addToGroup( SynchronizedHeaderView *view )
     {
         QObject::connect( view,SIGNAL(sectionResized(int , int , int )),
                 // Destruction of this will be handled by the action itself.
-                new SlotToBoostFunction_int_int_int(*it,boost::bind(&SynchronizedHeaderView::resizeSectionFuckingQT,*it,_1,_3)),
+                new SlotToBoostFunction_int_int_int(*it,std::bind(&SynchronizedHeaderView::resizeSectionFuckingQT,*it,_1,_3)),
                 SLOT(handleSignal(int,int,int)));
 
         QObject::connect( *it,SIGNAL(sectionResized(int , int , int )),
                 // Destruction of this will be handled by the action itself.
-                new SlotToBoostFunction_int_int_int(view,boost::bind(&SynchronizedHeaderView::resizeSectionFuckingQT,view,_1,_3)),
+                new SlotToBoostFunction_int_int_int(view,std::bind(&SynchronizedHeaderView::resizeSectionFuckingQT,view,_1,_3)),
                 SLOT(handleSignal(int,int,int)));
     }
 
     QObject::connect( view,SIGNAL(sectionMoved(int , int , int )),
             // Destruction of this will be handled by the action itself.
-            new SlotToBoostFunction(view,boost::bind(&HeaderViewGroup::synchronizeState,this,view)),
+            new SlotToBoostFunction(view,std::bind(&HeaderViewGroup::synchronizeState,this,view)),
             SLOT(handleSignal()));
 
     m_groupChilds.push_back( view );

--- a/logWitch/GUITools/SynchronizedHeaderView.h
+++ b/logWitch/GUITools/SynchronizedHeaderView.h
@@ -9,7 +9,6 @@
 #define SYNCHRONIZEDHEADERVIEW_H_
 
 #include <list>
-#include <boost/shared_ptr.hpp>
 #include <QtGui>
 #include <QHeaderView>
 
@@ -52,7 +51,7 @@ public:
 
 
 private:
-    boost::shared_ptr<HeaderViewGroup> m_group;
+    std::shared_ptr<HeaderViewGroup> m_group;
 };
 
 /**

--- a/logWitch/GUITools/WidgetStateSaver.cpp
+++ b/logWitch/GUITools/WidgetStateSaver.cpp
@@ -19,7 +19,7 @@ WidgetStateSaver::~WidgetStateSaver()
 {}
 
 void WidgetStateSaver::addElementToWatch( QObject *obj,
-        boost::shared_ptr<ObjectStateSavingInterface> stateSaver )
+        std::shared_ptr<ObjectStateSavingInterface> stateSaver )
 {
     DEBUG_WIDGETSTATESAFER("adding object to watch " <<obj);
     m_myWatchedObjects.insert( ObjectStateDumper::value_type( obj, stateSaver ) );

--- a/logWitch/GUITools/WidgetStateSaver.h
+++ b/logWitch/GUITools/WidgetStateSaver.h
@@ -11,7 +11,7 @@
 #include <map>
 #include <list>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <qobject.h>
 
 #define DEBUG_WIDGETSTATESAFER( x ) ;
@@ -24,7 +24,7 @@ public:
 	/**
 	 * An implementation should dump the state to the WidgetState here.
 	 */
-	virtual boost::shared_ptr<ObjectState> dumpState( QObject *objectToDump, QObject *parentalObject ) const = 0;
+	virtual std::shared_ptr<ObjectState> dumpState( QObject *objectToDump, QObject *parentalObject ) const = 0;
 
 	/**
 	 * Replays the previous saved state to the object.
@@ -39,7 +39,7 @@ class ObjectState
 {
 public:
 	ObjectState() : m_isValid( false ) { }
-	ObjectState( boost::shared_ptr<const ObjectStateSavingInterface> replayer, QObject *obj ) : m_isValid( true ), m_object( obj ), m_replayer( replayer ) { }
+	ObjectState( std::shared_ptr<const ObjectStateSavingInterface> replayer, QObject *obj ) : m_isValid( true ), m_object( obj ), m_replayer( replayer ) { }
 
 	bool isValid() const{ return m_isValid; }
 
@@ -50,7 +50,7 @@ protected:
 
 	QObject *m_object;
 
-	boost::shared_ptr<const ObjectStateSavingInterface> m_replayer;
+	std::shared_ptr<const ObjectStateSavingInterface> m_replayer;
 };
 
 
@@ -73,7 +73,7 @@ public:
 	 * @param obj Object to dump the state for
 	 * @param stateSaver The Class which knows how to dump and restore the state.
 	 */
-	void addElementToWatch( QObject *obj, boost::shared_ptr<ObjectStateSavingInterface> stateSaver );
+	void addElementToWatch( QObject *obj, std::shared_ptr<ObjectStateSavingInterface> stateSaver );
 
 	/**
 	 * Call this if the window gets out of focus to save the state.
@@ -95,7 +95,7 @@ public:
 	void switchState( QObject *newObject);
 
 private:
-	typedef std::map<QObject *, boost::shared_ptr<ObjectStateSavingInterface> > ObjectStateDumper;
+	typedef std::map<QObject *, std::shared_ptr<ObjectStateSavingInterface> > ObjectStateDumper;
 
 	/**
 	 * This list contains the watched objects with their corresponding stateDumpers.
@@ -103,7 +103,7 @@ private:
 	 */
 	ObjectStateDumper m_myWatchedObjects;
 
-	typedef std::list< boost::shared_ptr<ObjectState> > ObjectStateList;
+	typedef std::list< std::shared_ptr<ObjectState> > ObjectStateList;
 
 	typedef std::map<QObject *, ObjectStateList> StateSaveMap;
 

--- a/logWitch/LogData/LogEntry.cpp
+++ b/logWitch/LogData/LogEntry.cpp
@@ -52,7 +52,7 @@ const QVariant &LogEntry::getAttribute( int idx ) const
     return m_attributes[idx];
 }
 
-boost::shared_ptr<const QString> LogEntry::getAttributeAsString( int idx ) const
+std::shared_ptr<const QString> LogEntry::getAttributeAsString( int idx ) const
 {
     Q_ASSERT( idx >= 0 && idx < myFactory->getNumberOfFields() );
 
@@ -61,12 +61,12 @@ boost::shared_ptr<const QString> LogEntry::getAttributeAsString( int idx ) const
         return value.value<TSharedConstQString>();
     else
     {
-        return boost::shared_ptr<const QString>( new QString( value.toString() ) );
+        return std::shared_ptr<const QString>( new QString( value.toString() ) );
     }
 }
 
-boost::shared_ptr<const QString> LogEntry::getAttributeAsString( int idx
-        , boost::function<QString(const QVariant &)> customFormater  ) const
+std::shared_ptr<const QString> LogEntry::getAttributeAsString( int idx
+        , std::function<QString(const QVariant &)> customFormater  ) const
 {
     Q_ASSERT( idx >= 0 && idx < myFactory->getNumberOfFields() );
 
@@ -75,7 +75,7 @@ boost::shared_ptr<const QString> LogEntry::getAttributeAsString( int idx
         return value.value<TSharedConstQString>();
     else
     {
-        return boost::shared_ptr<const QString>( new QString( customFormater( value ) ) );
+        return std::shared_ptr<const QString>( new QString( customFormater( value ) ) );
     }
 }
 

--- a/logWitch/LogData/LogEntry.h
+++ b/logWitch/LogData/LogEntry.h
@@ -9,7 +9,6 @@
 #define LOGENTRYATTRIBUTES_H_
 
 #include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <QtCore/QMetaType>
 
@@ -61,8 +60,8 @@ private:
 	LogEntryFactory *myFactory;
 };
 
-typedef boost::shared_ptr<LogEntry> TSharedLogEntry;
-typedef boost::shared_ptr<const LogEntry> TconstSharedLogEntry;
+typedef std::shared_ptr<LogEntry> TSharedLogEntry;
+typedef std::shared_ptr<const LogEntry> TconstSharedLogEntry;
 
 Q_DECLARE_METATYPE(TSharedLogEntry)
 Q_DECLARE_METATYPE(TconstSharedLogEntry)

--- a/logWitch/LogData/LogEntry.h
+++ b/logWitch/LogData/LogEntry.h
@@ -8,8 +8,6 @@
 #ifndef LOGENTRYATTRIBUTES_H_
 #define LOGENTRYATTRIBUTES_H_
 
-#include <boost/function.hpp>
-
 #include <QtCore/QMetaType>
 
 #include <vector>
@@ -48,7 +46,7 @@ public:
 	 * it will be converted to. (internally we user a cache)
 	 */
     TSharedConstQString getAttributeAsString( int idx ) const;
-	TSharedConstQString getAttributeAsString( int idx, boost::function<QString(const QVariant &)> customFormater ) const;
+	TSharedConstQString getAttributeAsString( int idx, std::function<QString(const QVariant &)> customFormater ) const;
 
 private:
 	/**

--- a/logWitch/LogData/LogEntryAttributeNames.cpp
+++ b/logWitch/LogData/LogEntryAttributeNames.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "LogData/LogEntryAttributeNames.h"
-#include <boost/make_shared.hpp>
 
 ImportExportDescription::~ImportExportDescription()
 {  }
@@ -41,9 +40,9 @@ namespace
                 return QVariant( value );
         }
 
-        boost::shared_ptr<ImportExportDescription> clone() const
+        std::shared_ptr<ImportExportDescription> clone() const
         {
-            return boost::make_shared<QStringToNumber>( *this );
+            return std::make_shared<QStringToNumber>( *this );
         }
     };
 
@@ -87,9 +86,9 @@ namespace
             }
         }
 
-        boost::shared_ptr<ImportExportDescription> clone() const
+        std::shared_ptr<ImportExportDescription> clone() const
         {
-            return boost::make_shared<QStringToDateTime>( *this );
+            return std::make_shared<QStringToDateTime>( *this );
         }
     private:
         QString m_timeFormat;
@@ -103,9 +102,9 @@ namespace
             return str;
         }
 
-        boost::shared_ptr<ImportExportDescription> clone() const
+        std::shared_ptr<ImportExportDescription> clone() const
         {
-            return boost::make_shared<QStringToVariant>( *this );
+            return std::make_shared<QStringToVariant>( *this );
         }
     };
 }
@@ -125,36 +124,36 @@ LogEntryAttributeNames::LogEntryAttributeNames()
 ,attDescProcess("process",tr("Process"))
 ,attDescProcessName("processName",tr("Process Name"))
 ,attDescFunctionName("funcName",tr("Function Name"))
-,m_defaultCellIfo( false, 150, AttributeConfiguration::TQStringPair("unknown", tr("Unknown") ), boost::make_shared<QStringToVariant>() )
+,m_defaultCellIfo( false, 150, AttributeConfiguration::TQStringPair("unknown", tr("Unknown") ), std::make_shared<QStringToVariant>() )
 {
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescNumber.first       , AttributeConfiguration( false, 60 , attDescNumber
-            , boost::make_shared<QStringToNumber>() ) ) );
+            , std::make_shared<QStringToNumber>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescTimestamp.first    , AttributeConfiguration( false, 180, attDescTimestamp
-            , boost::make_shared<QStringToDateTime>("yyyy-MM-dd HH:mm:ss.zzz") ) ) );
+            , std::make_shared<QStringToDateTime>("yyyy-MM-dd HH:mm:ss.zzz") ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescMessage.first      , AttributeConfiguration( false, 500, attDescMessage
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescLoglevel.first     , AttributeConfiguration( true,  70 , attDescLoglevel
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescLoglevelNo.first     , AttributeConfiguration( true,  70 , attDescLoglevelNo
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescNDC.first          , AttributeConfiguration( true,  100, attDescNDC
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescThread.first       , AttributeConfiguration( true,  70 , attDescThread
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescLogger.first       , AttributeConfiguration( true,  250, attDescLogger
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescFileSource.first   , AttributeConfiguration( true,  150, attDescFileSource
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescFilename.first   , AttributeConfiguration( true,  100, attDescFilename
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescThreadName.first   , AttributeConfiguration( true,  125, attDescThreadName
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescProcess.first   , AttributeConfiguration( true,  70, attDescProcess
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescProcessName.first   , AttributeConfiguration( true,  125, attDescProcessName
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
     m_defaultCellIfos.insert( StringIntMap::value_type( attDescFunctionName.first   , AttributeConfiguration( true,  125, attDescFunctionName
-            , boost::make_shared<QStringToVariant>() ) ) );
+            , std::make_shared<QStringToVariant>() ) ) );
 }
 
 const AttributeConfiguration &LogEntryAttributeNames::getConfiguration( const QString &name ) const
@@ -166,7 +165,7 @@ const AttributeConfiguration &LogEntryAttributeNames::getConfiguration( const QS
         return m_defaultCellIfo;
 }
 
-AttributeConfiguration::AttributeConfiguration( bool caching, int defaultCellWidth, TQStringPair namesIn,  boost::shared_ptr<ImportExportDescription> factory )
+AttributeConfiguration::AttributeConfiguration( bool caching, int defaultCellWidth, TQStringPair namesIn,  std::shared_ptr<ImportExportDescription> factory )
 : caching( caching )
 , defaultCellWidth( defaultCellWidth )
 , names( namesIn )

--- a/logWitch/LogData/LogEntryAttributeNames.h
+++ b/logWitch/LogData/LogEntryAttributeNames.h
@@ -8,7 +8,6 @@
 #ifndef LOGENTRYATTRIBUTENAMES_H_
 #define LOGENTRYATTRIBUTENAMES_H_
 
-#include <boost/function.hpp>
 #include <QtCore/QtCore>
 
 class ImportExportDescription

--- a/logWitch/LogData/LogEntryAttributeNames.h
+++ b/logWitch/LogData/LogEntryAttributeNames.h
@@ -8,7 +8,6 @@
 #ifndef LOGENTRYATTRIBUTENAMES_H_
 #define LOGENTRYATTRIBUTENAMES_H_
 
-#include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <QtCore/QtCore>
 
@@ -22,14 +21,14 @@ public:
     virtual const QString getImportExportDescription();
     virtual void setImportExportDescription( const QString & );
 
-    virtual boost::shared_ptr<ImportExportDescription> clone() const = 0;
+    virtual std::shared_ptr<ImportExportDescription> clone() const = 0;
 };
 
 struct ExportToQStringAdapter
 {
-    ExportToQStringAdapter( boost::shared_ptr<ImportExportDescription> desc ):m_desc(desc){ }
+    ExportToQStringAdapter( std::shared_ptr<ImportExportDescription> desc ):m_desc(desc){ }
     QString operator()(const QVariant &str ){ return (*m_desc)(str); };
-    boost::shared_ptr<ImportExportDescription> m_desc;
+    std::shared_ptr<ImportExportDescription> m_desc;
 };
 
 class AttributeConfiguration
@@ -37,7 +36,7 @@ class AttributeConfiguration
 public:
     typedef std::pair<QString,QString> TQStringPair;
 
-    AttributeConfiguration( bool caching, int defaultCellWidth, TQStringPair names, boost::shared_ptr<ImportExportDescription> factory );
+    AttributeConfiguration( bool caching, int defaultCellWidth, TQStringPair names, std::shared_ptr<ImportExportDescription> factory );
     AttributeConfiguration( const AttributeConfiguration& cfg );
     AttributeConfiguration &operator=( const AttributeConfiguration& other );
 
@@ -45,7 +44,7 @@ public:
     int defaultCellWidth;
     TQStringPair names;
 
-    boost::shared_ptr<ImportExportDescription> attributeFactory;
+    std::shared_ptr<ImportExportDescription> attributeFactory;
 };
 
 class LogEntryAttributeNames

--- a/logWitch/LogData/LogEntryFactory.cpp
+++ b/logWitch/LogData/LogEntryFactory.cpp
@@ -25,9 +25,9 @@ LogEntryFactory::~LogEntryFactory()
 
 }
 
-boost::shared_ptr<LogEntry> LogEntryFactory::getNewLogEntry()
+std::shared_ptr<LogEntry> LogEntryFactory::getNewLogEntry()
 {
-	boost::shared_ptr<LogEntry> attr( new LogEntry(this, m_defaultLine ) );
+	std::shared_ptr<LogEntry> attr( new LogEntry(this, m_defaultLine ) );
 
 	return attr;
 }
@@ -43,11 +43,11 @@ void LogEntryFactory::addField( const AttributeConfiguration cfg )
 	m_fieldDescriptions.push_back( cfg );
 
 	if( cfg.caching )
-	    m_fieldCaches.push_back( boost::shared_ptr< ObjectCache<ObjectCacheQStringSignaller> >( new ObjectCache<ObjectCacheQStringSignaller> ) );
+	    m_fieldCaches.push_back( std::shared_ptr< ObjectCache<ObjectCacheQStringSignaller> >( new ObjectCache<ObjectCacheQStringSignaller> ) );
 	else
-	    m_fieldCaches.push_back( boost::shared_ptr< ObjectPasser<ObjectCacheQStringSignaller> >( new ObjectPasser<ObjectCacheQStringSignaller> ) );
+	    m_fieldCaches.push_back( std::shared_ptr< ObjectPasser<ObjectCacheQStringSignaller> >( new ObjectPasser<ObjectCacheQStringSignaller> ) );
 
-	m_defaultLine.push_back( QVariant::fromValue( m_fieldCaches.back()->getObject( boost::shared_ptr<QString>(new QString("")) ) ) );
+	m_defaultLine.push_back( QVariant::fromValue( m_fieldCaches.back()->getObject( std::shared_ptr<QString>(new QString("")) ) ) );
 }
 
 int LogEntryFactory::getNumberOfFields( ) const

--- a/logWitch/LogData/LogEntryFactory.h
+++ b/logWitch/LogData/LogEntryFactory.h
@@ -9,7 +9,6 @@
 #define LOGENTRYATTRIBUTEFACTORY_H_
 
 #include <vector>
-#include <boost/shared_ptr.hpp>
 #include "Types.h"
 #include "LogData/LogEntryAttributeNames.h"
 
@@ -32,7 +31,7 @@ public:
 
 	virtual ~LogEntryFactory();
 
-	boost::shared_ptr<LogEntry> getNewLogEntry();
+	std::shared_ptr<LogEntry> getNewLogEntry();
 
 	/**
 	 * Adds a field at the end of the fields and sets the new cfg for this field.
@@ -80,7 +79,7 @@ public:
 private:
 	std::vector< AttributeConfiguration > m_fieldDescriptions;
 
-	std::vector< boost::shared_ptr<GetObjectIF<ObjectCacheQStringSignaller> > > m_fieldCaches;
+	std::vector< std::shared_ptr<GetObjectIF<ObjectCacheQStringSignaller> > > m_fieldCaches;
 
 	std::vector< QVariant > m_defaultLine;
 

--- a/logWitch/LogData/LogEntryParser.h
+++ b/logWitch/LogData/LogEntryParser.h
@@ -7,7 +7,6 @@
 
 #ifndef LOGENTRYPARSER_H_
 #define LOGENTRYPARSER_H_
-#include <boost/shared_ptr.hpp>
 
  #include <QtGui>
 #include <QtCore/QObject>
@@ -56,7 +55,7 @@ public:
 	 * will be available and unchanged after calling initParser till
 	 * destruction.
 	 */
-	virtual boost::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const = 0;
+	virtual std::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const = 0;
 
 	// This block is the later called signals methods.
 protected:

--- a/logWitch/LogData/LogEntryParserModelConfiguration.cpp
+++ b/logWitch/LogData/LogEntryParserModelConfiguration.cpp
@@ -9,14 +9,13 @@
 
 #include <limits>
 #include <algorithm>
-#include <boost/bind/bind.hpp>
 #include <LogData/EntryToTextFormaterDefault.h>
 
 #include <QtCore>
 
 #include "LogData/LogEntryFactory.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 LogEntryParserModelConfiguration::LogEntryParserModelConfiguration( const QString &configurationString, std::shared_ptr<LogEntryFactory> factory )
     : m_formater( new EntryToTextFormaterDefault )
@@ -148,7 +147,7 @@ void LogEntryParserModelConfiguration::restoreHintsFromSettings()
 
         m_fieldWidthHints.clear();
         std::for_each( vList.begin(), vList.end(),
-                boost::bind( &convertToAndPushBack<int>, &m_fieldWidthHints, _1 ) );
+                std::bind( &convertToAndPushBack<int>, &m_fieldWidthHints, _1 ) );
 
         m_fieldWidthHintsLoaded = true;
     }
@@ -159,7 +158,7 @@ void LogEntryParserModelConfiguration::restoreHintsFromSettings()
 
         m_fieldShowHint.clear();
         std::for_each( vList.begin(), vList.end(),
-                boost::bind( &convertToAndPushBack<bool>, &m_fieldShowHint, _1 ) );
+                std::bind( &convertToAndPushBack<bool>, &m_fieldShowHint, _1 ) );
 
         m_fieldShowHintLoaded = true;
     }
@@ -170,7 +169,7 @@ void LogEntryParserModelConfiguration::restoreHintsFromSettings()
 
         m_fieldOrderHint.clear();
         std::for_each( vList.begin(), vList.end(),
-                boost::bind( &convertToAndPushBack<int>, &m_fieldOrderHint, _1 ) );
+                std::bind( &convertToAndPushBack<int>, &m_fieldOrderHint, _1 ) );
 
         m_fieldOrderHintLoaded = true;
     }
@@ -191,19 +190,19 @@ void LogEntryParserModelConfiguration::saveHintsToSettings() const
     QList<QVariant> vList;
 
     std::for_each( m_fieldWidthHints.begin(), m_fieldWidthHints.end(),
-            boost::bind( &QList<QVariant>::push_back, &vList, _1 ) );
+            std::bind( &QList<QVariant>::push_back, &vList, _1 ) );
 
     settings.setValue( "Widths", vList );
 
     vList.clear();
     std::for_each( m_fieldShowHint.begin(), m_fieldShowHint.end(),
-            boost::bind( &QList<QVariant>::push_back, &vList, _1 ) );
+            std::bind( &QList<QVariant>::push_back, &vList, _1 ) );
 
     settings.setValue( "Show", vList );
 
     vList.clear();
     std::for_each( m_fieldOrderHint.begin(), m_fieldOrderHint.end(),
-            boost::bind( &QList<QVariant>::push_back, &vList, _1 ) );
+            std::bind( &QList<QVariant>::push_back, &vList, _1 ) );
 
     settings.setValue( "Order", vList );
 

--- a/logWitch/LogData/LogEntryParserModelConfiguration.cpp
+++ b/logWitch/LogData/LogEntryParserModelConfiguration.cpp
@@ -18,7 +18,7 @@
 
 using namespace boost::placeholders;
 
-LogEntryParserModelConfiguration::LogEntryParserModelConfiguration( const QString &configurationString, boost::shared_ptr<LogEntryFactory> factory )
+LogEntryParserModelConfiguration::LogEntryParserModelConfiguration( const QString &configurationString, std::shared_ptr<LogEntryFactory> factory )
     : m_formater( new EntryToTextFormaterDefault )
     , m_attr( factory )
     , m_configurationString( configurationString )

--- a/logWitch/LogData/LogEntryParserModelConfiguration.h
+++ b/logWitch/LogData/LogEntryParserModelConfiguration.h
@@ -8,7 +8,6 @@
 #ifndef LOGENTRYPARSERMODELCONFIGURATION_H_
 #define LOGENTRYPARSERMODELCONFIGURATION_H_
 #include <QtCore/QtCore>
-#include <boost/shared_ptr.hpp>
 
 
 class EntryToTextFormater;
@@ -30,7 +29,7 @@ public:
      *
      * @param configurationString This string is an identifier to save and load default settings.
      */
-	LogEntryParserModelConfiguration( const QString &configurationString, boost::shared_ptr<LogEntryFactory> factory );
+	LogEntryParserModelConfiguration( const QString &configurationString, std::shared_ptr<LogEntryFactory> factory );
 	virtual ~LogEntryParserModelConfiguration();
 
 	/**
@@ -45,15 +44,15 @@ public:
 	 * The formatter is used to format a logEntry to a human readable html.
 	 * This html can than be displayed to the user.
 	 */
-	boost::shared_ptr<EntryToTextFormater> getEntryToTextFormater() const { return m_formater;};
+	std::shared_ptr<EntryToTextFormater> getEntryToTextFormater() const { return m_formater;};
 
-	void setEntryToTextFormater( boost::shared_ptr<EntryToTextFormater> fmt ){ m_formater = fmt;}
+	void setEntryToTextFormater( std::shared_ptr<EntryToTextFormater> fmt ){ m_formater = fmt;}
 
 	/**
 	 * Returns the corresponding factory for creating log entries.
 	 * This factory also hold the names for the columns referenced here.
 	 */
-	boost::shared_ptr<const LogEntryFactory> getLogEntryFactory() const { return m_attr;}
+	std::shared_ptr<const LogEntryFactory> getLogEntryFactory() const { return m_attr;}
 
 	/**
 	 * Returns the suggested width of the column.
@@ -118,9 +117,9 @@ public:
 private:
 	QVector<QString> m_hierarchySplitstrings;
 
-	boost::shared_ptr<EntryToTextFormater> m_formater;
+	std::shared_ptr<EntryToTextFormater> m_formater;
 
-	boost::shared_ptr<LogEntryFactory> m_attr;
+	std::shared_ptr<LogEntryFactory> m_attr;
 
 	QVector<int> m_fieldWidthHints;
 	const QString m_configurationString;
@@ -133,7 +132,7 @@ private:
 	bool m_fieldOrderHintLoaded;
 };
 
-typedef boost::shared_ptr<LogEntryParserModelConfiguration> TSharedLogEntryParserModelConfiguration;
-typedef boost::shared_ptr<const LogEntryParserModelConfiguration> TSharedConstLogEntryParserModelConfiguration;
+typedef std::shared_ptr<LogEntryParserModelConfiguration> TSharedLogEntryParserModelConfiguration;
+typedef std::shared_ptr<const LogEntryParserModelConfiguration> TSharedConstLogEntryParserModelConfiguration;
 
 #endif /* LOGENTRYPARSERMODELCONFIGURATION_H_ */

--- a/logWitch/LogData/LogEntryParser_Logfile.cpp
+++ b/logWitch/LogData/LogEntryParser_Logfile.cpp
@@ -8,7 +8,6 @@
 #include "LogEntryParser_Logfile.h"
 
 #include <boost/assign/list_of.hpp>
-#include <boost/foreach.hpp>
 
 #include <QRegExp>
 #include <QtCore/QtCore>
@@ -336,7 +335,7 @@ TSharedNewLogEntryMessage LogEntryParser_Logfile::getEntries()
 //      qDebug() << "After matching: " << double(nMilliseconds)/1000 << " seconds";
 //    }
 
-    BOOST_FOREACH( boost::shared_ptr<PreLogEntry> preEntry, firstWorkPackage->m_preLogEntries )
+    for ( std::shared_ptr<PreLogEntry> preEntry : firstWorkPackage->m_preLogEntries )
     {
       entryReturn->entries.push_back( createLogEntry(*preEntry) );
     }

--- a/logWitch/LogData/LogEntryParser_Logfile.cpp
+++ b/logWitch/LogData/LogEntryParser_Logfile.cpp
@@ -7,8 +7,6 @@
 
 #include "LogEntryParser_Logfile.h"
 
-#include <boost/assign/list_of.hpp>
-
 #include <QRegExp>
 #include <QtCore/QtCore>
 #include <QtConcurrent>
@@ -53,10 +51,7 @@ LogEntryParser_Logfile::LogEntryParser_Logfile(  std::shared_ptr<ParserStreamGet
         myFactory->getFieldConfiguration(i).defaultCellWidth, true);
   }
 
-  const auto fieldOrderHint = boost::assign::list_of(0)(5)(1)(2)(3)(4);
-  m_myModelConfig->setFieldOrderHint(
-      QVector<int>(fieldOrderHint.begin(), fieldOrderHint.end()),
-      true);
+  m_myModelConfig->setFieldOrderHint({0, 5, 1, 2, 3, 4}, true);
 }
 
 LogEntryParser_Logfile::~LogEntryParser_Logfile()

--- a/logWitch/LogData/LogEntryParser_Logfile.h
+++ b/logWitch/LogData/LogEntryParser_Logfile.h
@@ -10,8 +10,6 @@
 
 #include "LogEntryParser.h"
 
-#include <boost/scoped_ptr.hpp>
-
 #include <QFile>
 #include <QTextStream>
 #include <QtCore/QtCore>
@@ -29,7 +27,7 @@ class LogEntryParser_Logfile
 {
 	Q_OBJECT
 public:
-	LogEntryParser_Logfile( boost::shared_ptr<ParserStreamGetter> getter );
+	LogEntryParser_Logfile( std::shared_ptr<ParserStreamGetter> getter );
 
 	~LogEntryParser_Logfile();
 
@@ -39,7 +37,7 @@ public:
 
 	void run();
 
-	virtual boost::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
+	virtual std::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
 
 	QString getName() const;
 signals:
@@ -54,19 +52,19 @@ private:
 
 	bool m_abort;
 
-	boost::shared_ptr<ParserStreamGetter> m_getter;
+	std::shared_ptr<ParserStreamGetter> m_getter;
 
-	boost::shared_ptr<QTextStream> m_logfileStream;
+	std::shared_ptr<QTextStream> m_logfileStream;
 
-	boost::shared_ptr<QRegExp> lineMessageRegex;
+	std::shared_ptr<QRegExp> lineMessageRegex;
 
 	QRegExp cellRegex;
 
 	QString timeFormat;
 
-	boost::shared_ptr<LogEntryFactory> myFactory;
+	std::shared_ptr<LogEntryFactory> myFactory;
 
-	boost::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
+	std::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
 
 	int m_logEntryNumber;
 
@@ -74,7 +72,7 @@ private:
 	class PreLogEntry;
 	class WorkPackage;
 
-	boost::shared_ptr<LogfileLine> analyzeLine() const;
+	std::shared_ptr<LogfileLine> analyzeLine() const;
 	TSharedLogEntry createLogEntry( PreLogEntry& pre );
 
 };

--- a/logWitch/LogData/LogEntryParser_LogfileLWI.cpp
+++ b/logWitch/LogData/LogEntryParser_LogfileLWI.cpp
@@ -34,7 +34,7 @@ void LogEntryParser_LogfileLWI::startEmiting()
     start(LowPriority);
 }
 
-boost::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_LogfileLWI::getParserModelConfiguration() const
+std::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_LogfileLWI::getParserModelConfiguration() const
 {
   return m_myModelConfig;
 }
@@ -165,7 +165,7 @@ bool LogEntryParser_LogfileLWI::initParser()
 
   m_factory->disallowAddingFields();
   qDebug() << "Using Model context: " << modelContext;
-  m_myModelConfig = boost::shared_ptr<LogEntryParserModelConfiguration>(
+  m_myModelConfig = std::shared_ptr<LogEntryParserModelConfiguration>(
       new LogEntryParserModelConfiguration(modelContext, m_factory));
   // TODO: Splitstrings?
   //m_myModelConfig->setHierarchySplitString( 4, "\\.");

--- a/logWitch/LogData/LogEntryParser_LogfileLWI.h
+++ b/logWitch/LogData/LogEntryParser_LogfileLWI.h
@@ -32,7 +32,7 @@ public:
 
     bool initParser();
 
-    virtual boost::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
+    virtual std::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
 
 signals:
     void newEntry( TconstSharedNewLogEntryMessage );
@@ -57,9 +57,9 @@ private:
 
     QString m_stashedLine;
 
-    boost::shared_ptr<LogEntryFactory> m_factory;
+    std::shared_ptr<LogEntryFactory> m_factory;
 
-    boost::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
+    std::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
 
     int m_logEntryNumber;
 

--- a/logWitch/LogData/LogEntryStreamGetter.h
+++ b/logWitch/LogData/LogEntryStreamGetter.h
@@ -24,7 +24,7 @@ public:
    * if something went wrong. If there is something wring, getError can be used
    * to retrieve an error message.
    */
-  boost::shared_ptr<QTextStream> getStream() = 0;
+  std::shared_ptr<QTextStream> getStream() = 0;
 
   QString getError() const { return m_error; }
 

--- a/logWitch/LogData/NewLogEntryMessage.h
+++ b/logWitch/LogData/NewLogEntryMessage.h
@@ -24,8 +24,8 @@ public:
     std::list<TSharedLogEntry> entries;
 };
 
-typedef boost::shared_ptr<NewLogEntryMessage> TSharedNewLogEntryMessage;
-typedef boost::shared_ptr<const NewLogEntryMessage> TconstSharedNewLogEntryMessage;
+typedef std::shared_ptr<NewLogEntryMessage> TSharedNewLogEntryMessage;
+typedef std::shared_ptr<const NewLogEntryMessage> TconstSharedNewLogEntryMessage;
 
 
 #endif /* NEWLOGENTRYMESSAGE_H_ */

--- a/logWitch/LogData/ObjectCache.hxx
+++ b/logWitch/LogData/ObjectCache.hxx
@@ -7,7 +7,6 @@
 
 #ifndef OBJECTCACHE_H_
 #define OBJECTCACHE_H_
-#include <boost/shared_ptr.hpp>
 #include <set>
 #include <QtCore/QObject>
 #include "Types.h"
@@ -23,7 +22,7 @@ class ObjectCacheQStringSignaller
     Q_OBJECT
 public:
     typedef const QString StType;
-    typedef boost::shared_ptr<StType> shStType;
+    typedef std::shared_ptr<StType> shStType;
 
 signals:
     // This is not working in QT, typedefs must be the same!

--- a/logWitch/LogData/ParserStreamGetter.cpp
+++ b/logWitch/LogData/ParserStreamGetter.cpp
@@ -7,7 +7,7 @@
 
 #include "LogData/ParserStreamGetter.h"
 
-ParserStreamGetter::ParserStreamGetter(  const QString name, boost::shared_ptr<QTextStream> textStream )
+ParserStreamGetter::ParserStreamGetter(  const QString name, std::shared_ptr<QTextStream> textStream )
 : m_name( name )
 , m_textStream( textStream )
 {

--- a/logWitch/LogData/ParserStreamGetter.h
+++ b/logWitch/LogData/ParserStreamGetter.h
@@ -8,7 +8,7 @@
 #ifndef LOGWITCH_LOGDATA_PARSERSTREAMGETTER_H_
 #define LOGWITCH_LOGDATA_PARSERSTREAMGETTER_H_
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <QtCore/qobject.h>
 #include <QTextStream>
@@ -20,7 +20,7 @@
 class ParserStreamGetter
 {
 public:
-  ParserStreamGetter( const QString name, boost::shared_ptr<QTextStream> textStream = boost::shared_ptr<QTextStream>() );
+  ParserStreamGetter( const QString name, std::shared_ptr<QTextStream> textStream = std::shared_ptr<QTextStream>() );
 
   virtual ~ParserStreamGetter();
 
@@ -29,7 +29,7 @@ public:
    * if something went wrong. If there is something wring, getError can be used
    * to retrieve an error message.
    */
-  virtual boost::shared_ptr<QTextStream> getStream() {return m_textStream; }
+  virtual std::shared_ptr<QTextStream> getStream() {return m_textStream; }
 
   /**
    * In case of errors, this is a human readable string with the error reason.
@@ -47,7 +47,7 @@ protected:
 
   QString m_error;
 
-  boost::shared_ptr<QTextStream> m_textStream;
+  std::shared_ptr<QTextStream> m_textStream;
 };
 
 

--- a/logWitch/LogData/ParserStreamGetterFile.cpp
+++ b/logWitch/LogData/ParserStreamGetterFile.cpp
@@ -12,12 +12,12 @@
 namespace
 {
   struct DeleterQTextStream{
-    DeleterQTextStream(boost::shared_ptr<QFile> file): file(file){}
+    DeleterQTextStream(std::shared_ptr<QFile> file): file(file){}
 
     void operator()(QTextStream *obj) {
       delete obj;
     }
-    boost::shared_ptr<QFile> file;
+    std::shared_ptr<QFile> file;
   };
 }
 
@@ -27,11 +27,11 @@ ParserStreamGetterFile::ParserStreamGetterFile(const QString &filename)
 {
 }
 
-boost::shared_ptr<QTextStream> ParserStreamGetterFile::getStream()
+std::shared_ptr<QTextStream> ParserStreamGetterFile::getStream()
 {
   if (!m_textStream)
   {
-    boost::shared_ptr<QFile> file( new QFile(m_filename) );
+    std::shared_ptr<QFile> file( new QFile(m_filename) );
 
     if (!file->open(QIODevice::ReadOnly | QIODevice::Text))
     {

--- a/logWitch/LogData/ParserStreamGetterFile.h
+++ b/logWitch/LogData/ParserStreamGetterFile.h
@@ -15,7 +15,7 @@ class ParserStreamGetterFile: public ParserStreamGetter
 public:
   ParserStreamGetterFile(const QString &filename);
 
-  virtual boost::shared_ptr<QTextStream> getStream();
+  virtual std::shared_ptr<QTextStream> getStream();
 
 private:
   QString m_filename;

--- a/logWitch/LogData/test/test_LogEntryParser_Logfile.cpp
+++ b/logWitch/LogData/test/test_LogEntryParser_Logfile.cpp
@@ -11,7 +11,6 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
-#include <boost/foreach.hpp>
 
 #include "LogEntryStorerForTesting.h"
 #include "LogData/LogEntry.h"
@@ -114,7 +113,7 @@ BOOST_AUTO_TEST_CASE( multiThreadedParsing )
   BOOST_CHECK( tester->m_finished );
 
   int i = 0;
-  BOOST_FOREACH( TSharedLogEntry entry, tester->m_entries)
+  for ( TSharedLogEntry entry : tester->m_entries)
   {
     QString s;
     QTextStream ts(&s);
@@ -138,7 +137,7 @@ BOOST_AUTO_TEST_CASE( multiThreadedParsingMultiline )
   BOOST_CHECK( tester->m_finished );
 
   int i = 0;
-  BOOST_FOREACH( TSharedLogEntry entry, tester->m_entries)
+  for ( TSharedLogEntry entry : tester->m_entries)
   {
     QString s;
     QTextStream ts(&s);

--- a/logWitch/LogData/test/test_LogEntryParser_Logfile.cpp
+++ b/logWitch/LogData/test/test_LogEntryParser_Logfile.cpp
@@ -48,24 +48,24 @@ void fillStream(QTextStream& ts, bool withEndl=false, bool withMultilineMessage=
 /**
  * Performs the test and returns the testing object for final inspection.
  */
-boost::shared_ptr<LogEntryStorerForTesting> performTest(
+std::shared_ptr<LogEntryStorerForTesting> performTest(
       boost::function<void(QTextStream&)> prepare )
 {
   QString s;
-  boost::shared_ptr<QTextStream> textStream( new QTextStream(&s) );
+  std::shared_ptr<QTextStream> textStream( new QTextStream(&s) );
   prepare(*textStream);
 
-  boost::shared_ptr<ParserStreamGetter> getter( new ParserStreamGetter("name", textStream) );
-  boost::shared_ptr<LogEntryParser> parser( new LogEntryParser_Logfile( getter ) );
+  std::shared_ptr<ParserStreamGetter> getter( new ParserStreamGetter("name", textStream) );
+  std::shared_ptr<LogEntryParser> parser( new LogEntryParser_Logfile( getter ) );
 
-  boost::shared_ptr<LogEntryStorerForTesting> tester( new LogEntryStorerForTesting( parser.get() ) );
+  std::shared_ptr<LogEntryStorerForTesting> tester( new LogEntryStorerForTesting( parser.get() ) );
   tester->start();
   return tester;
 }
 
 BOOST_AUTO_TEST_CASE( bugLastLogLineWithoutEndl )
 {
-  boost::shared_ptr<LogEntryStorerForTesting> tester = performTest( boost::bind(&fillStream, _1, false, false) );
+  std::shared_ptr<LogEntryStorerForTesting> tester = performTest( std::bind(&fillStream, _1, false, false) );
   BOOST_CHECK( tester->m_finished );
 
   BOOST_CHECK_EQUAL( tester->m_entries.size(), 4 );
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( bugLastLogLineWithoutEndl )
 
 BOOST_AUTO_TEST_CASE( bugLastLogLineWithEndl )
 {
-  boost::shared_ptr<LogEntryStorerForTesting> tester = performTest( boost::bind(&fillStream, _1, true, false) );
+  std::shared_ptr<LogEntryStorerForTesting> tester = performTest( std::bind(&fillStream, _1, true, false) );
   BOOST_CHECK( tester->m_finished );
 
   BOOST_CHECK_EQUAL( tester->m_entries.size(), 4 );
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE( bugLastLogLineWithEndl )
 
 BOOST_AUTO_TEST_CASE( bugLastLogLineWithoutEndlMultiLine )
 {
-  boost::shared_ptr<LogEntryStorerForTesting> tester = performTest( boost::bind(&fillStream, _1, false, true) );
+  std::shared_ptr<LogEntryStorerForTesting> tester = performTest( std::bind(&fillStream, _1, false, true) );
   BOOST_CHECK( tester->m_finished );
 
   BOOST_CHECK_EQUAL( tester->m_entries.size(), 4 );
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE( bugLastLogLineWithoutEndlMultiLine )
 
 BOOST_AUTO_TEST_CASE( bugLastLogLineWithEndlMultiLine )
 {
-  boost::shared_ptr<LogEntryStorerForTesting> tester = performTest( boost::bind(&fillStream, _1, true, true) );
+  std::shared_ptr<LogEntryStorerForTesting> tester = performTest( std::bind(&fillStream, _1, true, true) );
   BOOST_CHECK( tester->m_finished );
 
   BOOST_CHECK_EQUAL( tester->m_entries.size(), 4 );
@@ -112,7 +112,7 @@ void filStreamWithIncrementingMessage( QTextStream& ts, int count, bool multilin
 
 BOOST_AUTO_TEST_CASE( multiThreadedParsing )
 {
-  boost::shared_ptr<LogEntryStorerForTesting> tester = performTest( boost::bind(&filStreamWithIncrementingMessage, _1, 20000, false) );
+  std::shared_ptr<LogEntryStorerForTesting> tester = performTest( std::bind(&filStreamWithIncrementingMessage, _1, 20000, false) );
   BOOST_CHECK( tester->m_finished );
 
   int i = 0;
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE( multiThreadedParsing )
 
 BOOST_AUTO_TEST_CASE( multiThreadedParsingMultiline )
 {
-  boost::shared_ptr<LogEntryStorerForTesting> tester = performTest( boost::bind(&filStreamWithIncrementingMessage, _1, 30000, true) );
+  std::shared_ptr<LogEntryStorerForTesting> tester = performTest( std::bind(&filStreamWithIncrementingMessage, _1, 30000, true) );
   BOOST_CHECK( tester->m_finished );
 
   int i = 0;

--- a/logWitch/LogData/test/test_LogEntryParser_Logfile.cpp
+++ b/logWitch/LogData/test/test_LogEntryParser_Logfile.cpp
@@ -11,14 +11,12 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
-#include <boost/bind/bind.hpp>
-#include <boost/function.hpp>
 #include <boost/foreach.hpp>
 
 #include "LogEntryStorerForTesting.h"
 #include "LogData/LogEntry.h"
 
-using namespace boost::placeholders;
+using namespace std::placeholders;
 
 void fillStream(QTextStream& ts, bool withEndl=false, bool withMultilineMessage=false)
 {
@@ -49,7 +47,7 @@ void fillStream(QTextStream& ts, bool withEndl=false, bool withMultilineMessage=
  * Performs the test and returns the testing object for final inspection.
  */
 std::shared_ptr<LogEntryStorerForTesting> performTest(
-      boost::function<void(QTextStream&)> prepare )
+      std::function<void(QTextStream&)> prepare )
 {
   QString s;
   std::shared_ptr<QTextStream> textStream( new QTextStream(&s) );

--- a/logWitch/LogEntryTableWindow.cpp
+++ b/logWitch/LogEntryTableWindow.cpp
@@ -257,7 +257,7 @@ void LogEntryTableWindow::exportLogfile(const QString &filename)
               == option;
           std::vector<TconstSharedLogEntry> entries;
 
-          boost::any lock = m_model->getLock();
+          std::any lock = m_model->getLock();
 
           m_timeFormatModel->generateExportList(entries, range.topLeft(),
               range.bottomRight(), params);

--- a/logWitch/LogEntryTableWindow.cpp
+++ b/logWitch/LogEntryTableWindow.cpp
@@ -9,8 +9,6 @@
 
 #include <limits>
 
-#include <boost/scoped_ptr.hpp>
-
 #include <QHBoxLayout>
 #include <QLineEdit>
 #include <QMessageBox>
@@ -238,7 +236,7 @@ void LogEntryTableWindow::exportLogfile(const QString &filename)
     const QItemSelectionRange& range = selection.front();
     if (!range.isEmpty())
     {
-      boost::scoped_ptr<DialogExportOptions> dlg(new DialogExportOptions);
+      std::unique_ptr<DialogExportOptions> dlg(new DialogExportOptions);
       dlg->setExportOption(DialogExportOptions::All);
 
       if (dlg->exec())

--- a/logWitch/LogEntryTableWindow.cpp
+++ b/logWitch/LogEntryTableWindow.cpp
@@ -67,7 +67,7 @@ void LogEntryTableWindow::updateHeaderPositionToModel(int, int, int)
     m_model->setHeaderData(view->logicalIndex(col), Qt::Horizontal, col, 514);
 }
 
-LogEntryTableWindow::LogEntryTableWindow( boost::shared_ptr<LogEntryTableModel> model, QWidget *parent)
+LogEntryTableWindow::LogEntryTableWindow( std::shared_ptr<LogEntryTableModel> model, QWidget *parent)
 : QMdiSubWindow(parent)
 , m_model(model)
 , m_splitter( new QSplitter(Qt::Vertical))
@@ -274,7 +274,7 @@ TSharedRuleTable LogEntryTableWindow::getRuleTable()
   return m_proxyModel->getRuleTable();
 }
 
-void LogEntryTableWindow::addFilter(boost::shared_ptr<LogEntryFilter> flt)
+void LogEntryTableWindow::addFilter(std::shared_ptr<LogEntryFilter> flt)
 {
   m_proxyModel->addFilter(flt);
 }

--- a/logWitch/LogEntryTableWindow.h
+++ b/logWitch/LogEntryTableWindow.h
@@ -7,7 +7,6 @@
 
 #ifndef LOGENTRYTABLEWINDOW_H_
 #define LOGENTRYTABLEWINDOW_H_
-#include <boost/shared_ptr.hpp>
 
 #include <QDockWidget>
 #include <QMdiSubWindow>
@@ -30,13 +29,13 @@ class LogEntryTableWindow: public QMdiSubWindow
 {
 Q_OBJECT
 public:
-  LogEntryTableWindow(boost::shared_ptr<LogEntryTableModel> model,
+  LogEntryTableWindow(std::shared_ptr<LogEntryTableModel> model,
       QWidget *parent = NULL);
   virtual ~LogEntryTableWindow();
 
   QModelIndex mapToSource(const QModelIndex & proxyIndex) const;
 
-  void addFilter(boost::shared_ptr<LogEntryFilter> flt);
+  void addFilter(std::shared_ptr<LogEntryFilter> flt);
 
   TSharedRuleTable getRuleTable();
 
@@ -78,7 +77,7 @@ private slots:
   void onDoubleClick(const QModelIndex & index);
 
 private:
-  boost::shared_ptr<LogEntryTableModel> m_model;
+  std::shared_ptr<LogEntryTableModel> m_model;
 
   QSplitter *m_splitter;
 

--- a/logWitch/Models/LogEntryFilterChain.cpp
+++ b/logWitch/Models/LogEntryFilterChain.cpp
@@ -16,14 +16,14 @@ LogEntryFilterChain::~LogEntryFilterChain()
 {
 }
 
-void LogEntryFilterChain::addFilter( boost::shared_ptr<LogEntryFilter> flt )
+void LogEntryFilterChain::addFilter( std::shared_ptr<LogEntryFilter> flt )
 {
 	flt->setParent( this );
 
 	m_filterChain.push_back( flt );
 }
 
-void LogEntryFilterChain::removeFilter( boost::shared_ptr<LogEntryFilter>  flt )
+void LogEntryFilterChain::removeFilter( std::shared_ptr<LogEntryFilter>  flt )
 {
 	flt->setParent( NULL );
 

--- a/logWitch/Models/LogEntryFilterChain.h
+++ b/logWitch/Models/LogEntryFilterChain.h
@@ -8,7 +8,6 @@
 #ifndef LOGENTRYFILTERCHAIN_H_
 #define LOGENTRYFILTERCHAIN_H_
 
-#include <boost/shared_ptr.hpp>
 #include "Models/LogEntryFilter.h"
 #include <list>
 #include <QtCore/QtCore>
@@ -23,9 +22,9 @@ public:
 
 	virtual ~LogEntryFilterChain();
 
-	void addFilter( boost::shared_ptr< LogEntryFilter> );
+	void addFilter( std::shared_ptr< LogEntryFilter> );
 
-	void removeFilter( boost::shared_ptr< LogEntryFilter> );
+	void removeFilter( std::shared_ptr< LogEntryFilter> );
 
 	virtual bool filterEntry( TconstSharedLogEntry entry ) const;
 
@@ -37,7 +36,7 @@ signals:
 	void filterUpdateFinished();
 
 private:
-	typedef std::list< boost::shared_ptr<  LogEntryFilter> > TFilterChain;
+	typedef std::list< std::shared_ptr<  LogEntryFilter> > TFilterChain;
 	TFilterChain m_filterChain;
 
 	int m_changeCounter;

--- a/logWitch/Models/LogEntryRemoveFilter.cpp
+++ b/logWitch/Models/LogEntryRemoveFilter.cpp
@@ -17,12 +17,12 @@ LogEntryRemoveFilter::~LogEntryRemoveFilter()
 {
 }
 
-void LogEntryRemoveFilter::addEntry( boost::shared_ptr<const QString> str )
+void LogEntryRemoveFilter::addEntry( std::shared_ptr<const QString> str )
 {
 	m_removeStrings.insert( str );
 }
 
-void LogEntryRemoveFilter::removeEntry( boost::shared_ptr<const QString> str )
+void LogEntryRemoveFilter::removeEntry( std::shared_ptr<const QString> str )
 {
 	m_removeStrings.erase( str );
 }

--- a/logWitch/Models/LogEntryRemoveFilter.h
+++ b/logWitch/Models/LogEntryRemoveFilter.h
@@ -8,14 +8,13 @@
 #ifndef LOGENTRYREMOVEFILTER_H_
 #define LOGENTRYREMOVEFILTER_H_
 #include "LogEntryFilter.h"
-#include <boost/shared_ptr.hpp>
 #include <set>
 
 class QString;
 
 struct ltShPtr
 {
-  template<class T> bool operator()(const boost::shared_ptr<T> &s1, const boost::shared_ptr<T> &s2) const
+  template<class T> bool operator()(const std::shared_ptr<T> &s1, const std::shared_ptr<T> &s2) const
   {
     return s1.get() < s2.get();
   }
@@ -28,16 +27,16 @@ public:
 	LogEntryRemoveFilter( int attrId );
 	~LogEntryRemoveFilter();
 
-	void addEntry( boost::shared_ptr<const QString> str );
+	void addEntry( std::shared_ptr<const QString> str );
 
-	void removeEntry( boost::shared_ptr<const QString> str );
+	void removeEntry( std::shared_ptr<const QString> str );
 
 	void clear();
 
 	virtual bool filterEntry( TconstSharedLogEntry entry ) const;
 
 private:
-	std::set<boost::shared_ptr<const QString>, ltShPtr > m_removeStrings;
+	std::set<std::shared_ptr<const QString>, ltShPtr > m_removeStrings;
 
 	int m_attributeID;
 };

--- a/logWitch/Models/LogEntryTableFilter.cpp
+++ b/logWitch/Models/LogEntryTableFilter.cpp
@@ -61,7 +61,7 @@ void LogEntryTableFilter::generateExportList( std::vector<TconstSharedLogEntry>&
   }
 }
 
-void LogEntryTableFilter::addFilter( boost::shared_ptr<LogEntryFilter> flt )
+void LogEntryTableFilter::addFilter( std::shared_ptr<LogEntryFilter> flt )
 {
 	m_filterChain.addFilter( flt );
 }

--- a/logWitch/Models/LogEntryTableFilter.cpp
+++ b/logWitch/Models/LogEntryTableFilter.cpp
@@ -9,7 +9,6 @@
 
 #include <QtGui>
 #include <algorithm>
-#include <boost/foreach.hpp>
 
 #include "Models/LogEntryTableModel.h"
 #include "LogData/LogEntry.h"
@@ -53,7 +52,7 @@ void LogEntryTableFilter::generateExportList( std::vector<TconstSharedLogEntry>&
     std::vector<TconstSharedLogEntry> tmpVec;
     m_exportOfSourceModel->generateExportList( tmpVec, srcFirst, srcLast, param );
 
-    BOOST_FOREACH( TconstSharedLogEntry e, tmpVec )
+    for ( TconstSharedLogEntry e : tmpVec )
     {
       if (filterAcceptInt(e))
         ls.push_back(e);

--- a/logWitch/Models/LogEntryTableFilter.h
+++ b/logWitch/Models/LogEntryTableFilter.h
@@ -31,7 +31,7 @@ public:
 
 	QVariant data(const QModelIndex &index, int role) const;
 
-	void addFilter( boost::shared_ptr<LogEntryFilter> );
+	void addFilter( std::shared_ptr<LogEntryFilter> );
 
 	TSharedRuleTable getRuleTable();
 

--- a/logWitch/Models/LogEntryTableModel.cpp
+++ b/logWitch/Models/LogEntryTableModel.cpp
@@ -20,7 +20,7 @@
 #include "LogData/LogEntryParserModelConfiguration.h"
 #include "LogData/LogEntryAttributeNames.h"
 
-LogEntryTableModel::LogEntryTableModel( boost::shared_ptr<LogEntryParser> parser )
+LogEntryTableModel::LogEntryTableModel( std::shared_ptr<LogEntryParser> parser )
 	: m_table( )
 	, m_modelConfiguration( parser->getParserModelConfiguration() )
 	, m_entryLoader( parser )
@@ -315,5 +315,5 @@ void LogEntryTableModel::capture( bool active )
 
 std::any LogEntryTableModel::getLock()
 {
-    return boost::shared_ptr<QMutexLocker>( new QMutexLocker(&m_mutex) );
+    return std::shared_ptr<QMutexLocker>( new QMutexLocker(&m_mutex) );
 }

--- a/logWitch/Models/LogEntryTableModel.cpp
+++ b/logWitch/Models/LogEntryTableModel.cpp
@@ -313,7 +313,7 @@ void LogEntryTableModel::capture( bool active )
     m_captureActive = active;
 }
 
-boost::any LogEntryTableModel::getLock()
+std::any LogEntryTableModel::getLock()
 {
     return boost::shared_ptr<QMutexLocker>( new QMutexLocker(&m_mutex) );
 }

--- a/logWitch/Models/LogEntryTableModel.h
+++ b/logWitch/Models/LogEntryTableModel.h
@@ -8,7 +8,6 @@
 #ifndef LOGENTRYTABLEMODEL_H_
 #define LOGENTRYTABLEMODEL_H_
 
-#include <boost/shared_ptr.hpp>
 #include <any>
 
 #include <QAbstractTableModel>
@@ -33,7 +32,7 @@ class LogEntryTableModel: public QAbstractTableModel, public ExportableIfc
 public:
   static const int RawDataRole = Qt::UserRole;
 
-  LogEntryTableModel(boost::shared_ptr<LogEntryParser> parser);
+  LogEntryTableModel(std::shared_ptr<LogEntryParser> parser);
   virtual ~LogEntryTableModel();
 
   /**
@@ -155,7 +154,7 @@ private:
 
   TSharedLogEntryParserModelConfiguration m_modelConfiguration;
 
-  boost::shared_ptr<LogEntryParser> m_entryLoader;
+  std::shared_ptr<LogEntryParser> m_entryLoader;
 
   QString m_ModelName;
 

--- a/logWitch/Models/LogEntryTableModel.h
+++ b/logWitch/Models/LogEntryTableModel.h
@@ -9,7 +9,7 @@
 #define LOGENTRYTABLEMODEL_H_
 
 #include <boost/shared_ptr.hpp>
-#include <boost/any.hpp>
+#include <any>
 
 #include <QAbstractTableModel>
 #include <QtCore/QtCore>
@@ -91,7 +91,7 @@ public:
    * As long as the returned any contains its value (or is copied to another any)
    * the lock is being held. To release the lock, destroy the content of the any.
    */
-  boost::any getLock();
+  std::any getLock();
 
   void generateExportList( std::vector<TconstSharedLogEntry>& entries
       , QModelIndex first, QModelIndex last

--- a/logWitch/Models/LogEntryTableModelFileExporter.cpp
+++ b/logWitch/Models/LogEntryTableModelFileExporter.cpp
@@ -72,7 +72,7 @@ void LogEntryTableModelFileExporter::exportTo( const QString& filename )
 
 void LogEntryTableModelFileExporter::exportTo( const QString& filename, boost::function<TconstSharedLogEntry()> funcNextExportItem )
 {
-    boost::any lock = m_model.getLock();
+    std::any lock = m_model.getLock();
 
     QFile file( filename );
     file.open(QIODevice::WriteOnly);

--- a/logWitch/Models/LogEntryTableModelFileExporter.cpp
+++ b/logWitch/Models/LogEntryTableModelFileExporter.cpp
@@ -70,7 +70,7 @@ void LogEntryTableModelFileExporter::exportTo( const QString& filename )
     exportTo( filename, DumpAllEntries(m_model) );
 }
 
-void LogEntryTableModelFileExporter::exportTo( const QString& filename, boost::function<TconstSharedLogEntry()> funcNextExportItem )
+void LogEntryTableModelFileExporter::exportTo( const QString& filename, std::function<TconstSharedLogEntry()> funcNextExportItem )
 {
     std::any lock = m_model.getLock();
 

--- a/logWitch/Models/LogEntryTableModelFileExporter.h
+++ b/logWitch/Models/LogEntryTableModelFileExporter.h
@@ -9,8 +9,6 @@
 #define LOGENTRYTABLEMODELFILEEXPORTER_H_
 #include <QtCore>
 
-#include <boost/function.hpp>
-
 #include "LogData/LogEntry.h"
 
 class LogEntryTableModel;
@@ -29,7 +27,7 @@ public:
 
     void exportTo( const QString& filename );
 
-    void exportTo( const QString& filename, boost::function<TconstSharedLogEntry()> funcNextExportItem );
+    void exportTo( const QString& filename, std::function<TconstSharedLogEntry()> funcNextExportItem );
 private:
     LogEntryTableModel& m_model;
 };

--- a/logWitch/Models/StringCacheTreeItem.h
+++ b/logWitch/Models/StringCacheTreeItem.h
@@ -8,7 +8,6 @@
 #ifndef STRINGCACHETREEITEM_H_
 #define STRINGCACHETREEITEM_H_
 
-#include <boost/shared_ptr.hpp>
 #include <list>
 #include "Types.h"
 #include <QtCore/QtCore>

--- a/logWitch/Models/StringCacheTreeModel.cpp
+++ b/logWitch/Models/StringCacheTreeModel.cpp
@@ -33,7 +33,7 @@ StringCacheTreeModel::~StringCacheTreeModel()
 
 }
 
-boost::shared_ptr<LogEntryFilter> StringCacheTreeModel::getFilter() const
+std::shared_ptr<LogEntryFilter> StringCacheTreeModel::getFilter() const
 {
 	return m_myFilter;
 }

--- a/logWitch/Models/StringCacheTreeModel.h
+++ b/logWitch/Models/StringCacheTreeModel.h
@@ -42,7 +42,7 @@ public:
 
     bool setData( const QModelIndex &index, const QVariant& value, int role );
 
-    boost::shared_ptr<LogEntryFilter> getFilter() const;
+    std::shared_ptr<LogEntryFilter> getFilter() const;
 
 private:
     void dataChangedToChildren(const QModelIndex &index );
@@ -61,13 +61,13 @@ public slots:
 	void newStringElement( TSharedConstQString );
 
 private:
-	boost::shared_ptr<StringCacheTreeItem> m_rootNode;
+	std::shared_ptr<StringCacheTreeItem> m_rootNode;
 
 	QString m_modelname;
 
-	boost::shared_ptr<QRegExp> m_splitRegex;
+	std::shared_ptr<QRegExp> m_splitRegex;
 
-	boost::shared_ptr<LogEntryRemoveFilter> m_myFilter;
+	std::shared_ptr<LogEntryRemoveFilter> m_myFilter;
 
 	TSharedConstQString m_undefinedString;
 };

--- a/logWitch/ParserActionInterface.h
+++ b/logWitch/ParserActionInterface.h
@@ -8,7 +8,7 @@
 #ifndef LOGWITCH_PARSERACTIONINTERFACE_H_
 #define LOGWITCH_PARSERACTIONINTERFACE_H_
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 class LogEntryParser;
 
@@ -26,7 +26,7 @@ namespace logwitch
 		/**
 		 * A new parser has been created an shall be passed to the application
 		 */
-		virtual void newParser(boost::shared_ptr<LogEntryParser> parser, bool alreadyInitialized = false) = 0;
+		virtual void newParser(std::shared_ptr<LogEntryParser> parser, bool alreadyInitialized = false) = 0;
 	};
 }
 

--- a/logWitch/Plugins/LogSource/dummy/DummyLogSource.cpp
+++ b/logWitch/Plugins/LogSource/dummy/DummyLogSource.cpp
@@ -50,7 +50,7 @@ void DummyLogSource::fillMenu( QMenu* menu )
 void DummyLogSource::openDummyLogfile()
 {
   // Create table with log entries and a new model for this
-  boost::shared_ptr<LogEntryParser_dummy> parser(new LogEntryParser_dummy);
+  std::shared_ptr<LogEntryParser_dummy> parser(new LogEntryParser_dummy);
   m_parser = parser;
   updateErrorEmit();
 

--- a/logWitch/Plugins/LogSource/dummy/DummyLogSource.h
+++ b/logWitch/Plugins/LogSource/dummy/DummyLogSource.h
@@ -7,7 +7,6 @@
 
 #ifndef LOGWITCH_PLUGINS_LOGSOURCE_DUMMY_DUMMYLOGSOURCE_H_
 #define LOGWITCH_PLUGINS_LOGSOURCE_DUMMY_DUMMYLOGSOURCE_H_
-#include <boost/smart_ptr/shared_ptr.hpp>
 
 #include <QObject>
 #include <QAction>
@@ -48,7 +47,7 @@ namespace logwitch
 
       private:
         // This is the last created dummy logfile parser
-        boost::shared_ptr<LogEntryParser_dummy> m_parser;
+        std::shared_ptr<LogEntryParser_dummy> m_parser;
 
         QAction* m_actionErrorCreation;
       };

--- a/logWitch/Plugins/LogSource/dummy/LogEntryParser_dummy.cpp
+++ b/logWitch/Plugins/LogSource/dummy/LogEntryParser_dummy.cpp
@@ -31,7 +31,7 @@ LogEntryParser_dummy::LogEntryParser_dummy ()
   myFactory->addField(names.getConfiguration("logger"));
   myFactory->disallowAddingFields();
 
-  m_myModelConfig = boost::shared_ptr<LogEntryParserModelConfiguration>(
+  m_myModelConfig = std::shared_ptr<LogEntryParserModelConfiguration>(
       new LogEntryParserModelConfiguration("DummyLogger", myFactory));
   m_myModelConfig->setHierarchySplitString(4, "\\.");
 
@@ -166,7 +166,7 @@ TSharedLogEntry LogEntryParser_dummy::getNextLogEntry ()
   return entry;
 }
 
-boost::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_dummy::getParserModelConfiguration () const
+std::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_dummy::getParserModelConfiguration () const
 {
   return m_myModelConfig;
 }

--- a/logWitch/Plugins/LogSource/dummy/LogEntryParser_dummy.cpp
+++ b/logWitch/Plugins/LogSource/dummy/LogEntryParser_dummy.cpp
@@ -7,8 +7,6 @@
 
 #include "LogEntryParser_dummy.h"
 
-#include <boost/assign/list_of.hpp>
-
 #include "LogData/LogEntry.h"
 #include "LogData/LogEntryAttributeNames.h"
 #include "LogData/LogEntryFactory.h"
@@ -41,9 +39,7 @@ LogEntryParser_dummy::LogEntryParser_dummy ()
     m_myModelConfig->setFieldWidthHint(i, cfg.defaultCellWidth, true);
   }
 
-  const auto fieldOrderHint = boost::assign::list_of(0)(4)(1)(2)(3);
-  m_myModelConfig->setFieldOrderHint(
-      QVector<int>(fieldOrderHint.begin(), fieldOrderHint.end()), true);
+  m_myModelConfig->setFieldOrderHint({0, 4, 1, 2, 3}, true);
 }
 
 LogEntryParser_dummy::~LogEntryParser_dummy ()

--- a/logWitch/Plugins/LogSource/dummy/LogEntryParser_dummy.h
+++ b/logWitch/Plugins/LogSource/dummy/LogEntryParser_dummy.h
@@ -41,7 +41,7 @@ namespace logwitch
 
         void setEmitError( bool v) { m_emitError=v; }
 
-        boost::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration () const;
+        std::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration () const;
 
         QString getName () const
         {
@@ -69,9 +69,9 @@ namespace logwitch
 
         bool m_emitError = false;
 
-        boost::shared_ptr<LogEntryFactory> myFactory;
+        std::shared_ptr<LogEntryFactory> myFactory;
 
-        boost::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
+        std::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
       };
     }
   }

--- a/logWitch/Plugins/LogSource/log4cplus/Log4cplusGUIIntegration.cpp
+++ b/logWitch/Plugins/LogSource/log4cplus/Log4cplusGUIIntegration.cpp
@@ -78,7 +78,7 @@ Log4cplusGUIIntegration::~Log4cplusGUIIntegration ()
 void Log4cplusGUIIntegration::openPort ()
 {
   int port = m_port->value();
-  boost::shared_ptr<LogEntryParser_log4cplusSocket> socketParser(
+  std::shared_ptr<LogEntryParser_log4cplusSocket> socketParser(
       new LogEntryParser_log4cplusSocket(port));
 
   m_parserActionIfc->newParser(socketParser);

--- a/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.cpp
+++ b/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.cpp
@@ -8,7 +8,6 @@
 #include "Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.h"
 
 #include <algorithm>
-#include <boost/shared_ptr.hpp>
 #include <boost/assign/list_of.hpp>
 #include <iostream>
 
@@ -62,12 +61,12 @@ LogEntryParser_log4cplusSocket::LogEntryParser_log4cplusSocket (int port)
   myFactory->addField(names.getConfiguration("ndc"));
   myFactory->disallowAddingFields();
 
-  m_myModelConfig = boost::shared_ptr<LogEntryParserModelConfiguration>(
+  m_myModelConfig = std::shared_ptr<LogEntryParserModelConfiguration>(
       new LogEntryParserModelConfiguration("log4cplus", myFactory));
   m_myModelConfig->setHierarchySplitString(4, "\\.");
   m_myModelConfig->setHierarchySplitString(5, "/");
   m_myModelConfig->setEntryToTextFormater(
-      boost::shared_ptr<EntryToTextFormater>(new EntryToTextFormaterLog4cplus));
+      std::shared_ptr<EntryToTextFormater>(new EntryToTextFormaterLog4cplus));
 
   for (int i = 0; i < myFactory->getNumberOfFields(); ++i)
   {
@@ -148,7 +147,7 @@ void LogEntryParser_log4cplusSocket::newEntryFromReceiver (
   }
 }
 
-boost::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_log4cplusSocket::getParserModelConfiguration () const
+std::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_log4cplusSocket::getParserModelConfiguration () const
 {
   return m_myModelConfig;
 }

--- a/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.cpp
+++ b/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.cpp
@@ -8,7 +8,6 @@
 #include "Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.h"
 
 #include <algorithm>
-#include <boost/assign/list_of.hpp>
 #include <iostream>
 
 #include <log4cplus/socketappender.h>
@@ -73,10 +72,7 @@ LogEntryParser_log4cplusSocket::LogEntryParser_log4cplusSocket (int port)
     const AttributeConfiguration &cfg = myFactory->getFieldConfiguration(i);
     m_myModelConfig->setFieldWidthHint(i, cfg.defaultCellWidth, true);
   }
-  const auto fieldOrderHint = boost::assign::list_of(0)(7)(1)(2)(3)(4)(5)(6);
-  m_myModelConfig->setFieldOrderHint(
-      QVector<int>(fieldOrderHint.begin(), fieldOrderHint.end()),
-      true);
+  m_myModelConfig->setFieldOrderHint({0, 7, 1, 2, 3, 4, 5, 6}, true);
 
   connect(this, SIGNAL(newConnection()), this, SLOT(newIncomingConnection()));
 }

--- a/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.h
+++ b/logWitch/Plugins/LogSource/log4cplus/LogEntryParser_log4cplusSocket.h
@@ -9,8 +9,6 @@
 #define LOGENTRYPARSER_LOG4CPLUSSOCKET_H_
 #include <list>
 
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <log4cplus/helpers/socket.h>
 
@@ -44,7 +42,7 @@ public:
 
 	void startEmiting();
 
-	boost::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
+	std::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
 
 private slots:
 	void newIncomingConnection();
@@ -62,9 +60,9 @@ signals:
 private:
 	int m_port;
 
-	boost::shared_ptr<LogEntryFactory> myFactory;
+	std::shared_ptr<LogEntryFactory> myFactory;
 
-	boost::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
+	std::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
 
 	QString m_loglevelStringOff;
 	QString m_loglevelStringFatal;
@@ -111,7 +109,7 @@ private:
 private:
 	QTcpSocket *m_socket;
 
-	boost::shared_ptr<::log4cplus::helpers::SocketBuffer> m_buffer;
+	std::shared_ptr<::log4cplus::helpers::SocketBuffer> m_buffer;
 	quint64 m_bytesNeeded;
 	bool m_stateReadSize;
 

--- a/logWitch/Plugins/LogSource/python/LogEntryParser_pythonSocket.cpp
+++ b/logWitch/Plugins/LogSource/python/LogEntryParser_pythonSocket.cpp
@@ -13,7 +13,6 @@
 #include <boost/assign/list_of.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/python.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <Python.h>
 
@@ -48,7 +47,7 @@ LogEntryParser_pythonSocket::LogEntryParser_pythonSocket (int port)
   myFactory->addField(names.getConfiguration("funcName"));
   myFactory->disallowAddingFields();
 
-  m_myModelConfig = boost::shared_ptr<LogEntryParserModelConfiguration>(
+  m_myModelConfig = std::shared_ptr<LogEntryParserModelConfiguration>(
       new LogEntryParserModelConfiguration("python", myFactory));
   m_myModelConfig->setHierarchySplitString(4, "\\.");
   m_myModelConfig->setHierarchySplitString(5, "/");
@@ -134,7 +133,7 @@ void LogEntryParser_pythonSocket::newEntryFromReceiver (
   }
 }
 
-boost::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_pythonSocket::getParserModelConfiguration () const
+std::shared_ptr<LogEntryParserModelConfiguration> LogEntryParser_pythonSocket::getParserModelConfiguration () const
 {
   return m_myModelConfig;
 }

--- a/logWitch/Plugins/LogSource/python/LogEntryParser_pythonSocket.cpp
+++ b/logWitch/Plugins/LogSource/python/LogEntryParser_pythonSocket.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <iostream>
 
-#include <boost/assign/list_of.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/python.hpp>
 
@@ -59,9 +58,8 @@ LogEntryParser_pythonSocket::LogEntryParser_pythonSocket (int port)
     m_myModelConfig->setFieldWidthHint(i, cfg.defaultCellWidth, true);
   }
 
-  const auto fieldOrderHint = boost::assign::list_of(0)(7)(1)(2)(3)(4)(5)(6)(7)(8)(9)(10);
   m_myModelConfig->setFieldOrderHint(
-      QVector<int>(fieldOrderHint.begin(), fieldOrderHint.end()),
+      {0, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
       true);
 
   connect(this, SIGNAL(newConnection()), this, SLOT(newIncomingConnection()));

--- a/logWitch/Plugins/LogSource/python/LogEntryParser_pythonSocket.h
+++ b/logWitch/Plugins/LogSource/python/LogEntryParser_pythonSocket.h
@@ -11,8 +11,6 @@
 #include <cstdint>
 
 #include <boost/python.hpp>
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
 
 #include <log4cplus/helpers/socket.h>
 
@@ -46,7 +44,7 @@ public:
 
 	void startEmiting();
 
-	boost::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
+	std::shared_ptr<LogEntryParserModelConfiguration> getParserModelConfiguration() const;
 
 private Q_SLOTS:
 	void newIncomingConnection();
@@ -65,9 +63,9 @@ Q_SIGNALS:
 private:
 	int m_port;
 
-	boost::shared_ptr<LogEntryFactory> myFactory;
+	std::shared_ptr<LogEntryFactory> myFactory;
 
-	boost::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
+	std::shared_ptr<LogEntryParserModelConfiguration> m_myModelConfig;
 
 	QString m_name;
 

--- a/logWitch/Plugins/LogSource/python/PythonGUIIntegration.cpp
+++ b/logWitch/Plugins/LogSource/python/PythonGUIIntegration.cpp
@@ -78,7 +78,7 @@ PythonGUIIntegration::~PythonGUIIntegration ()
 void PythonGUIIntegration::openPort ()
 {
   int port = m_port->value();
-  boost::shared_ptr<LogEntryParser_pythonSocket> socketParser(
+  std::shared_ptr<LogEntryParser_pythonSocket> socketParser(
       new LogEntryParser_pythonSocket(port));
 
   m_parserActionIfc->newParser(socketParser);

--- a/logWitch/Types.h
+++ b/logWitch/Types.h
@@ -7,7 +7,7 @@
 
 #ifndef TYPES_H_
 #define TYPES_H_
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <QMetaType>
 #include <QString>
@@ -15,11 +15,11 @@
 class QString;
 class QVariant;
 
-typedef boost::shared_ptr<QString> TSharedQString;
-typedef boost::shared_ptr<const QString> TSharedConstQString;
+typedef std::shared_ptr<QString> TSharedQString;
+typedef std::shared_ptr<const QString> TSharedConstQString;
 
-typedef boost::shared_ptr<QVariant> TSharedQVariant;
-typedef boost::shared_ptr<const QVariant> TSharedConstQVariant;
+typedef std::shared_ptr<QVariant> TSharedQVariant;
+typedef std::shared_ptr<const QVariant> TSharedConstQVariant;
 
 Q_DECLARE_METATYPE(TSharedQString)
 Q_DECLARE_METATYPE ( TSharedConstQString );

--- a/logWitch/logfileanalyser.cpp
+++ b/logWitch/logfileanalyser.cpp
@@ -1,8 +1,5 @@
 #include "logfileanalyser.h"
 
-#include <boost/shared_ptr.hpp>
-#include <boost/smart_ptr/make_shared.hpp>
-
 #include <QtGui>
 #include <QFileDialog>
 #include <QLabel>
@@ -156,14 +153,14 @@ void LogfileAnalyser::showDocumentation()
 
 void LogfileAnalyser::openLogfile(const QString &fileName)
 {
-  boost::shared_ptr<LogEntryParser> parser(
+  std::shared_ptr<LogEntryParser> parser(
       new LogEntryParser_LogfileLWI(fileName));
   if (!parser->initParser())
   {
     qDebug() << " LWI-Parser failed: " << parser->getInitError();
     parser.reset(
         new LogEntryParser_Logfile(
-            boost::make_shared<ParserStreamGetterFile>(fileName)));
+            std::make_shared<ParserStreamGetterFile>(fileName)));
     if (parser->initParser())
       createWindowsFromParser(parser, true);
     else
@@ -195,12 +192,12 @@ void LogfileAnalyser::openLogfile()
   }
 }
 
-void LogfileAnalyser::newParser(boost::shared_ptr<LogEntryParser> parser, bool alreadyInitialized)
+void LogfileAnalyser::newParser(std::shared_ptr<LogEntryParser> parser, bool alreadyInitialized)
 {
 	createWindowsFromParser( parser, alreadyInitialized);
 }
 
-void LogfileAnalyser::createWindowsFromParser(boost::shared_ptr<LogEntryParser> parser, bool alreadyInitialized)
+void LogfileAnalyser::createWindowsFromParser(std::shared_ptr<LogEntryParser> parser, bool alreadyInitialized)
 {
   if (!alreadyInitialized && !parser->initParser())
   {
@@ -216,7 +213,7 @@ void LogfileAnalyser::createWindowsFromParser(boost::shared_ptr<LogEntryParser> 
     return;
   }
 
-  boost::shared_ptr<LogEntryTableModel> model(new LogEntryTableModel(parser));
+  std::shared_ptr<LogEntryTableModel> model(new LogEntryTableModel(parser));
 
   LogEntryTableWindow *wnd = new LogEntryTableWindow(model, ui.mdiArea);
   m_signalMultiplexer.setObject(wnd);

--- a/logWitch/logfileanalyser.h
+++ b/logWitch/logfileanalyser.h
@@ -1,7 +1,6 @@
 #ifndef LOGFILEANALYSER_H
 #define LOGFILEANALYSER_H
 
-#include <boost/shared_ptr.hpp>
 
 #include <QtCore>
 #include <QMainWindow>
@@ -34,7 +33,7 @@ public:
   LogfileAnalyser(QWidget *parent = 0);
   ~LogfileAnalyser();
 
-  void newParser(boost::shared_ptr<LogEntryParser> parser, bool alreadyInitialized) override;
+  void newParser(std::shared_ptr<LogEntryParser> parser, bool alreadyInitialized) override;
 
 public slots:
   void subWindowActivated(QMdiSubWindow *);
@@ -42,7 +41,7 @@ public slots:
   void showDocumentation();
 
 private:
-  void createWindowsFromParser(boost::shared_ptr<LogEntryParser> parser, bool alreadyInitialized = false);
+  void createWindowsFromParser(std::shared_ptr<LogEntryParser> parser, bool alreadyInitialized = false);
 
   Ui::LogfileAnalyserClass ui;
 
@@ -54,7 +53,7 @@ private:
   WidgetStateSaver *m_stateSaver;
   SignalMultiplexer m_signalMultiplexer;
 
-  boost::shared_ptr<HelpAssistant> m_helpAssistant;
+  std::shared_ptr<HelpAssistant> m_helpAssistant;
 
   void loadPlugins();
   void loadPlugins(QDir basePath);

--- a/test/test_StringCacheTreeItem.cpp
+++ b/test/test_StringCacheTreeItem.cpp
@@ -10,11 +10,9 @@
 #define BOOST_TEST_MODULE StringCacheTreeItem
 #include <boost/test/unit_test.hpp>
 
-#include <boost/make_shared.hpp>
-
 #include "Models/StringCacheTreeItem.h"
 
-using namespace boost;
+using namespace std;
 
 /**
  * This test is testing if adding items works well.


### PR DESCRIPTION
These commits reduce our reliance on Boost, replacing many Boost features with their modern C++17 counterparts.

The code will only compile after #5 and #6 have been applied.