### PR TITLE
Determine fall-back help-file path relative to the application binary

### DIFF
--- a/logWitch/Help/HelpAssistant.cpp
+++ b/logWitch/Help/HelpAssistant.cpp
@@ -95,7 +95,7 @@ bool HelpAssistant::startAssistant()
 
         if( !QFile::exists( helpFile ) )
         {
-            helpFile = "Help/" + helpFilename;
+            helpFile = QCoreApplication::applicationDirPath() + "/Help/" + helpFilename;
             if( !QFile::exists( helpFile ) )
             {
                 qDebug() << "Unable to find helpfile: " << helpFilename;


### PR DESCRIPTION
Doing it relative to the current working directory means that a developer build of LogWitch cannot find the file if it is started from the wrong directory.