### PR TITLE
Do not create `LogfileAnalyser` object before parsing the command line

### DIFF
--- a/logWitch/main.cpp
+++ b/logWitch/main.cpp
@@ -34,8 +34,6 @@ int main(int argc, char *argv[])
   QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, QApplication::applicationDirPath());
 #endif
 
-  LogfileAnalyser w;
-
   QCommandLineParser parser;
   parser.setApplicationDescription(QCoreApplication::translate("main", "This is a tool for analyzing logfiles or capturing remote log data.") );
   parser.addHelpOption();
@@ -45,6 +43,9 @@ int main(int argc, char *argv[])
   parser.addPositionalArgument("logfile", QCoreApplication::translate("main", "File to open"));
 
   parser.process(a);
+
+  LogfileAnalyser w;
+
   const QStringList positionalArguments = parser.positionalArguments();
   if (!positionalArguments.isEmpty())
   {


### PR DESCRIPTION
This fixes a segmentation fault in the destructor of `PythonGUIIntegration` when running `logwitch --help`.

The `LogfileAnalyser` class is responsible for loading plugins when it is created, and for unloading them upon destruction.

When the application is started with `--help`, Qt prints out a help text and quits early. The `LogfileAnalyser` object has already been created - and the plugins loaded - by that time, but its destructor is not invoked because the object is still within the scope of the `main()` function when Qt calls `exit()`. The crash then occurs inside the destructor of `PythonGUIIntegration` because it indirectly tries to access a `QCoreApplication` object that has already been destroyed.

Fix this issue by making sure that the plugins are only loaded after Qt has parsed the command line.